### PR TITLE
refactor(ci): move smoke tests to build stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Run smoke test (verify core modules import)
         run: |
           docker run --rm telegram-downloader:test python -c "
+          import asyncio; asyncio.set_event_loop(asyncio.new_event_loop())
           from src.config import load_config, ConfigError
           from src.config.schema import Config, SourceConfig
           from src.state.cursor import CursorStore


### PR DESCRIPTION
## Summary

Restructure CI pipeline to run smoke tests in the build stage after unit/integration tests pass.

## Changes

- **test job**: Runs unit + integration tests only (with coverage)
- **build job**: Runs smoke tests first, then Docker build + container validation
- Renamed `docker-smoke` to `build`
- `build` depends on `test` passing

## Pipeline Flow

```
test (3.11, 3.12)     →     build
├── unit tests              ├── smoke tests
├── integration tests       ├── Docker build
└── coverage check          └── container validation
```

## Note

Update branch protection required checks:
- Remove: `docker-smoke`
- Add: `build`