### PR TITLE
fix(ci): docs workflow triggers on main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'docs/**'
       - 'mkdocs.yml'


### PR DESCRIPTION
The docs workflow was configured to trigger on `master` branch, but this repo only has `main`. Changed to `main` so documentation deploys correctly.