### PR TITLE
feat: add flat storage option to skip channel subfolders

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -107,6 +107,9 @@ class Config(BaseModel):
     session_dir: Path = Field(default=Path("/app/.sessions"))
     log_file: Optional[Path] = None
 
+    # Storage structure
+    flat_structure: bool = Field(default=False)
+
     # Logging
     verbosity: Literal["quiet", "normal", "verbose"] = Field(default="normal")
 

--- a/src/main.py
+++ b/src/main.py
@@ -132,7 +132,8 @@ async def download_batch(
                     download_dir,
                     source,
                     fname,
-                    source_config
+                    source_config,
+                    config.flat_structure,
                 )
             except ValueError as e:
                 log.error(f"Path validation failed for {fname}: {e}")

--- a/src/organization/path_builder.py
+++ b/src/organization/path_builder.py
@@ -17,13 +17,16 @@ async def build_destination_path(
     source: BaseSource,
     filename: str,
     source_config: SourceConfig,
+    flat_structure: bool = False,
 ) -> Path:
     """
-    Build destination path with per-source folder structure.
+    Build destination path with optional per-source folder structure.
 
-    Creates folder structure: {base_dir}/{source_folder}/{filename}
+    Creates folder structure:
+    - flat_structure=False: {base_dir}/{source_folder}/{filename}
+    - flat_structure=True:  {base_dir}/{filename}
 
-    Folder name priority:
+    Folder name priority (when flat_structure=False):
     1. source_config.name (user-provided display name)
     2. source.get_display_name() (Telegram chat/topic name)
     3. Fallback to cursor key if sanitization results in empty string
@@ -38,6 +41,7 @@ async def build_destination_path(
         source: Source instance for display name and cursor key
         filename: Original filename from Telegram message
         source_config: Source configuration with optional name override
+        flat_structure: If True, store files directly in base_dir without subfolders
 
     Returns:
         Validated absolute path ready for download
@@ -54,6 +58,16 @@ async def build_destination_path(
         ... )
         >>> path
         Path('/downloads/Book_Club/book.epub')
+
+        >>> path = await build_destination_path(
+        ...     Path("/downloads"),
+        ...     forum_topic_source,
+        ...     "book.epub",
+        ...     SourceConfig(name="Book Club"),
+        ...     flat_structure=True
+        ... )
+        >>> path
+        Path('/downloads/book.epub')
     """
     # Get folder name: use config name, fallback to display name
     if source_config.name:
@@ -75,8 +89,11 @@ async def build_destination_path(
     # Sanitize filename
     safe_filename = sanitize_filename(filename)
 
-    # Build path: {base_dir}/{safe_folder}/{safe_filename}
-    dest_path = base_dir / safe_folder / safe_filename
+    # Build path based on structure preference
+    if flat_structure:
+        dest_path = base_dir / safe_filename
+    else:
+        dest_path = base_dir / safe_folder / safe_filename
 
     # Validate path safety (defense in depth)
     validated_path = validate_path_safety(base_dir, dest_path)

--- a/tests/unit/organization/__init__.py
+++ b/tests/unit/organization/__init__.py
@@ -1,0 +1,1 @@
+"""Organization module unit tests."""

--- a/tests/unit/organization/test_path_builder.py
+++ b/tests/unit/organization/test_path_builder.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for destination path construction.
+
+Tests both default (subfolder per source) and flat structure modes.
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from src.config.schema import SourceConfig
+from src.organization.path_builder import build_destination_path
+
+
+class MockSource:
+    """Mock source for testing path builder."""
+
+    def __init__(self, display_name: str = "Test Channel", cursor_key: str = "channel:-100123456"):
+        self._display_name = display_name
+        self._cursor_key = cursor_key
+
+    async def get_display_name(self) -> str:
+        return self._display_name
+
+    def get_cursor_key(self) -> str:
+        return self._cursor_key
+
+
+class TestBuildDestinationPathDefault:
+    """Tests for default subfolder structure (flat_structure=False)."""
+
+    @pytest.mark.asyncio
+    async def test_uses_config_name_for_folder(self, temp_dir):
+        """Should use source_config.name for folder when provided."""
+        source = MockSource(display_name="Telegram Name")
+        config = SourceConfig(url="https://t.me/test", name="Custom Name")
+
+        result = await build_destination_path(
+            temp_dir, source, "book.epub", config, flat_structure=False
+        )
+
+        assert result.parent.name == "Custom_Name"
+        assert result.name == "book.epub"
+
+    @pytest.mark.asyncio
+    async def test_uses_display_name_when_no_config_name(self, temp_dir):
+        """Should use source display name when config.name is not set."""
+        source = MockSource(display_name="Book Club Channel")
+        config = SourceConfig(url="https://t.me/test")
+
+        result = await build_destination_path(
+            temp_dir, source, "document.pdf", config, flat_structure=False
+        )
+
+        assert result.parent.name == "Book_Club_Channel"
+        assert result.name == "document.pdf"
+
+    @pytest.mark.asyncio
+    async def test_creates_subfolder(self, temp_dir):
+        """Should create the source subfolder."""
+        source = MockSource(display_name="Test Channel")
+        config = SourceConfig(url="https://t.me/test", name="Downloads")
+
+        result = await build_destination_path(
+            temp_dir, source, "file.txt", config, flat_structure=False
+        )
+
+        assert result.parent.exists()
+        assert result.parent.name == "Downloads"
+
+    @pytest.mark.asyncio
+    async def test_path_structure_with_subfolder(self, temp_dir):
+        """Should create path as base_dir/folder/filename."""
+        source = MockSource()
+        config = SourceConfig(url="https://t.me/test", name="MyFolder")
+
+        result = await build_destination_path(
+            temp_dir, source, "test.pdf", config, flat_structure=False
+        )
+
+        # Path should be base_dir / folder / filename
+        # Use resolve() to handle Windows short path format differences
+        expected = (temp_dir / "MyFolder" / "test.pdf").resolve()
+        assert result == expected
+
+
+class TestBuildDestinationPathFlat:
+    """Tests for flat structure mode (flat_structure=True)."""
+
+    @pytest.mark.asyncio
+    async def test_flat_structure_no_subfolder(self, temp_dir):
+        """Should place files directly in base_dir when flat_structure=True."""
+        source = MockSource(display_name="Test Channel")
+        config = SourceConfig(url="https://t.me/test", name="Would Be Folder")
+
+        result = await build_destination_path(
+            temp_dir, source, "book.epub", config, flat_structure=True
+        )
+
+        # File should be directly in base_dir, not in a subfolder
+        # Use resolve() to handle Windows short path format differences
+        assert result.parent == temp_dir.resolve()
+        assert result == (temp_dir / "book.epub").resolve()
+
+    @pytest.mark.asyncio
+    async def test_flat_structure_ignores_config_name(self, temp_dir):
+        """Flat structure should ignore source name for path construction."""
+        source = MockSource(display_name="Ignored Name")
+        config = SourceConfig(url="https://t.me/test", name="Also Ignored")
+
+        result = await build_destination_path(
+            temp_dir, source, "document.pdf", config, flat_structure=True
+        )
+
+        # No subfolder with any of the names
+        assert "Ignored" not in str(result)
+        assert result == (temp_dir / "document.pdf").resolve()
+
+    @pytest.mark.asyncio
+    async def test_flat_structure_creates_base_dir(self, temp_dir):
+        """Should create base directory when flat_structure=True."""
+        base = temp_dir / "nested" / "downloads"
+        source = MockSource()
+        config = SourceConfig(url="https://t.me/test")
+
+        result = await build_destination_path(
+            base, source, "file.txt", config, flat_structure=True
+        )
+
+        assert result.parent.exists()
+        assert result.parent == base.resolve()
+
+    @pytest.mark.asyncio
+    async def test_flat_structure_sanitizes_filename(self, temp_dir):
+        """Should sanitize filename even in flat mode."""
+        source = MockSource()
+        config = SourceConfig(url="https://t.me/test")
+
+        result = await build_destination_path(
+            temp_dir, source, "../../../etc/passwd", config, flat_structure=True
+        )
+
+        # Path traversal should be neutralized - slashes removed, file in base dir
+        assert result.parent == temp_dir.resolve()
+        assert "/" not in result.name
+        assert "\\" not in result.name  # No path separators
+
+
+class TestBuildDestinationPathDefaults:
+    """Tests for default parameter behavior."""
+
+    @pytest.mark.asyncio
+    async def test_default_is_subfolder_mode(self, temp_dir):
+        """Default should be subfolder mode (flat_structure=False)."""
+        source = MockSource(display_name="Default Test")
+        config = SourceConfig(url="https://t.me/test")
+
+        # Call without flat_structure parameter
+        result = await build_destination_path(
+            temp_dir, source, "test.pdf", config
+        )
+
+        # Should have subfolder
+        assert result.parent.name == "Default_Test"
+        assert result != (temp_dir / "test.pdf").resolve()
+
+
+class TestBuildDestinationPathSecurity:
+    """Security tests for both modes."""
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked_subfolder_mode(self, temp_dir):
+        """Path traversal should be blocked in subfolder mode."""
+        source = MockSource()
+        config = SourceConfig(url="https://t.me/test", name="../../escape")
+
+        result = await build_destination_path(
+            temp_dir, source, "file.txt", config, flat_structure=False
+        )
+
+        # Should not escape base_dir - use resolved path for comparison
+        resolved_temp = temp_dir.resolve()
+        assert str(resolved_temp) in str(result)
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked_flat_mode(self, temp_dir):
+        """Path traversal should be blocked in flat mode."""
+        source = MockSource()
+        config = SourceConfig(url="https://t.me/test")
+
+        result = await build_destination_path(
+            temp_dir, source, "../../etc/passwd", config, flat_structure=True
+        )
+
+        # Should not escape base_dir - use resolved path for comparison
+        resolved_temp = temp_dir.resolve()
+        assert str(resolved_temp) in str(result)
+        assert result.parent == resolved_temp


### PR DESCRIPTION
## Summary

- Adds `flat_structure` configuration option to store all downloaded files directly in the download directory without per-channel subfolders
- When `flat_structure: false` (default): files stored as `{download_dir}/{channel_name}/{filename}`
- When `flat_structure: true`: files stored as `{download_dir}/{filename}`

## Changes

- Add `flat_structure: bool` field to Config schema (default: false)
- Update `build_destination_path` to support flat mode
- Pass config option through main download flow
- Add comprehensive test coverage for both storage modes

## Usage

```yaml
# config.yaml
flat_structure: true
```

Or via environment variable:
```bash
TDL_FLAT_STRUCTURE=true
```

## Test plan

- [x] All existing tests pass (176 tests)
- [x] New tests cover flat structure behavior
- [x] New tests verify security (path traversal blocked in both modes)
- [x] Default behavior unchanged (backward compatible)