### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,19 @@ jobs:
       version: ${{ steps.release.outputs.version }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # Use conventional commits to determine version bumps
-          # feat: -> minor, fix: -> patch, feat!: or fix!: -> major
+          token: ${{ steps.app-token.outputs.token }}
           release-type: simple
-
-          # Create release PR with accumulated changes
-          # Merging the PR creates the release and tag
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Replace default `GITHUB_TOKEN` with a GitHub App token in the release-please workflow
- PRs created with the default token don't trigger other workflows (GitHub's infinite loop prevention), so the 4 required CI checks never ran on release PRs

## Changes

- Add `actions/create-github-app-token` step to generate a short-lived token
- Pass the token to `release-please-action`
- Requires `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret (already configured)

## Test plan

- [ ] Merge and push a conventional commit to main
- [ ] Verify release-please PR is created and CI checks trigger automatically