### PR TITLE
fix: downgrade Docker image to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Optimized for size and security with separate build and runtime stages
 
 # Build stage - includes build tools and compilers
-FROM python:3.14-slim AS builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
@@ -19,7 +19,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --user -r requirements.txt
 
 # Runtime stage - minimal dependencies only
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Downgrade Docker base image from Python 3.14 to 3.12
- Pyrogram 2.x calls `asyncio.get_event_loop()` in its sync wrapper, which raises `RuntimeError` on Python 3.14
- Python 3.12 matches the CI test environment

## Test plan

- [ ] Docker image builds successfully
- [ ] Container starts without RuntimeError
- [ ] Telegram authentication flow works