### PR TITLE
fix: handle bind-mount permissions with entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 
-# Install runtime dependencies only
+# Install runtime dependencies (gosu for entrypoint privilege drop)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
+        gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Python packages from builder stage to a shared location
@@ -38,32 +39,27 @@ COPY --from=builder /root/.local /usr/local
 # Copy application code
 COPY src/ ./src/
 COPY healthcheck.py .
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-# Create directories for runtime data
-RUN mkdir -p /downloads /.sessions && \
-    chmod 700 /.sessions
+# Create non-root user and runtime directories
+RUN useradd -m -u 1000 appuser && \
+    mkdir -p /downloads /app/.sessions && \
+    chown -R appuser:appuser /app /downloads
 
 # Environment variables
 ENV PYTHONUNBUFFERED=1 \
     TDL_DOWNLOAD_DIR=/downloads \
+    TDL_SESSION_DIR=/app/.sessions \
     TDL_DAEMON_HEALTH_FILE=/app/health_status.txt
 
 # Health check configuration for Docker orchestration
-# Validates daemon is running and updating health file
-# Interval: 2 minutes (check every 2min)
-# Timeout: 10 seconds (healthcheck.py should complete quickly)
-# Start period: 1 minute (allow startup validation time)
-# Retries: 3 (fail after 3 consecutive unhealthy checks)
 HEALTHCHECK --interval=2m \
             --timeout=10s \
             --start-period=1m \
             --retries=3 \
-            CMD python3 /app/healthcheck.py
+            CMD gosu appuser python3 /app/healthcheck.py
 
-# Run as non-root user for security
-RUN useradd -m -u 1000 appuser && \
-    chown -R appuser:appuser /app /downloads /.sessions
-USER appuser
-
-# Default command - runs main.py
+# Entrypoint fixes bind-mount permissions then drops to appuser
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "-m", "src.main"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ All configuration is done via environment variables with the `TDL_` prefix.
 - TDL_NOTIFICATIONS_DETAIL_LEVEL=summary  # minimal, summary, or detailed
 ```
 
+### Docker Environment
+
+```yaml
+# User/group ID for file permissions (arr-stack compatible)
+- PUID=1000  # default: 1000
+- PGID=1000  # default: 1000
+
+# Timezone
+- TZ=Europe/Lisbon
+
+# Store all files in download_dir without per-channel subfolders
+- TDL_FLAT_STRUCTURE=true
+```
+
 See the [full configuration reference](https://rfsbraz.github.io/telegram-downloader/configuration/) for all options.
 
 ## Examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,11 +71,40 @@ Examples:
     phone_number = "+1234567890"
     ```
 
-### Download Directory
+### Paths and Storage
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `TDL_DOWNLOAD_DIR` | path | `/downloads` | Base directory for downloaded files |
+| `TDL_FLAT_STRUCTURE` | boolean | `false` | Store all files in download dir without per-channel subfolders |
+
+When `TDL_FLAT_STRUCTURE` is `false` (default), files are organized as `{download_dir}/{channel_name}/{filename}`. When `true`, all files go directly into `{download_dir}/{filename}`.
+
+### Docker Environment
+
+These are standard Docker environment variables, not prefixed with `TDL_`.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PUID` | integer | `1000` | User ID for file ownership ([arr-stack](https://docs.linuxserver.io/general/understanding-puid-and-pgid/) convention) |
+| `PGID` | integer | `1000` | Group ID for file ownership |
+| `TZ` | string | `UTC` | Container timezone (e.g., `Europe/Lisbon`) |
+
+=== "Environment Variables"
+
+    ```yaml
+    - PUID=1000
+    - PGID=1000
+    - TZ=Europe/Lisbon
+    - TDL_FLAT_STRUCTURE=true
+    ```
+
+=== "config.toml"
+
+    ```toml
+    flat_structure = true
+    # PUID, PGID, and TZ are Docker-only (not in config.toml)
+    ```
 
 ## Daemon Configuration
 
@@ -261,6 +290,7 @@ api_id = 12345678
 api_hash = "abcdef1234567890abcdef1234567890"
 phone_number = "+1234567890"
 download_dir = "/downloads"
+flat_structure = true
 
 [daemon]
 enabled = true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -203,7 +203,7 @@ docker stats telegram-downloader
 ### 1. Non-Root User
 
 !!! tip "Verify Non-Root Execution"
-    Container already runs as UID 1000 (non-root). Verify:
+    Container runs as non-root by default (UID 1000). Override with `PUID`/`PGID` environment variables to match your host user. Verify:
 ```bash
 docker compose exec telegram-downloader whoami
 # Should output: appuser

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Ensure bind-mounted directories are writable by appuser (uid 1000)
+# Docker creates bind mounts as root, but the app runs as appuser
+for dir in /downloads /app/.sessions; do
+    if [ -d "$dir" ] && [ ! -w "$dir" ]; then
+        chown -R appuser:appuser "$dir" 2>/dev/null || true
+    fi
+done
+
+exec gosu appuser "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,21 @@
 #!/bin/sh
 set -e
 
-# Ensure bind-mounted directories are writable by appuser (uid 1000)
-# Docker creates bind mounts as root, but the app runs as appuser
+# Support PUID/PGID environment variables (arr-stack convention)
+# Defaults to 1000:1000 if not set
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Update appuser uid/gid if they differ from defaults
+if [ "$(id -u appuser)" != "$PUID" ] || [ "$(id -g appuser)" != "$PGID" ]; then
+    groupmod -o -g "$PGID" appuser 2>/dev/null || true
+    usermod -o -u "$PUID" appuser 2>/dev/null || true
+    chown -R appuser:appuser /app
+fi
+
+# Ensure bind-mounted directories are writable by appuser
 for dir in /downloads /app/.sessions; do
-    if [ -d "$dir" ] && [ ! -w "$dir" ]; then
+    if [ -d "$dir" ]; then
         chown -R appuser:appuser "$dir" 2>/dev/null || true
     fi
 done


### PR DESCRIPTION
## Summary

- Docker bind mounts inherit host permissions, so `appuser` can't write to volumes created by Docker as root
- The previous `USER appuser` + `chown` in Dockerfile only applies to image-baked directories, not bind mounts
- This caused `unable to open database file` on first run

## Changes

- Add `entrypoint.sh` that fixes bind-mount ownership then drops to `appuser` via `gosu`
- Fix `/.sessions` → `/app/.sessions` path mismatch (Dockerfile created wrong path)
- Add `TDL_SESSION_DIR` env var for consistency
- Healthcheck runs via `gosu appuser` to match runtime user

## Test plan

- [ ] Fresh `docker compose run --rm` works without manual `chown` on host
- [ ] Sessions and downloads directories are writable
- [ ] App runs as `appuser` (not root) after entrypoint