### PR TITLE
feat: add persistent download tracking via file_unique_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Telegram is great for sharing files, but manually downloading from multiple sour
 - Filters by extension, size, date, or filename pattern
 - Organizes files into folders by source
 - Skips duplicates automatically
+- Tracks downloads persistently — files aren't re-downloaded after being moved or renamed
 - Sends notifications when downloads complete
 
 ## Features
@@ -27,7 +28,7 @@ Telegram is great for sharing files, but manually downloading from multiple sour
 |---------|-------------|
 | **Multi-Source** | Channels, groups, supergroups, forum topics, private chats |
 | **Smart Filtering** | By extension, file size, date range, filename patterns |
-| **Auto-Organization** | Per-source folders, duplicate detection, conflict resolution |
+| **Auto-Organization** | Per-source folders, duplicate detection, conflict resolution, persistent download tracking |
 | **Daemon Mode** | Runs continuously with configurable check intervals |
 | **Notifications** | Discord webhooks, generic HTTP POST |
 | **Docker Native** | Multi-arch images (amd64/arm64), health checks, non-root |
@@ -131,6 +132,10 @@ All configuration is done via environment variables with the `TDL_` prefix.
 
 # Store all files in download_dir without per-channel subfolders
 - TDL_FLAT_STRUCTURE=true
+
+# Disable persistent download tracking (enabled by default)
+# When enabled, files won't be re-downloaded after being moved/renamed
+- TDL_TRACK_DOWNLOADS=true
 ```
 
 See the [full configuration reference](https://rfsbraz.github.io/telegram-downloader/configuration/) for all options.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,8 +77,11 @@ Examples:
 |----------|------|---------|-------------|
 | `TDL_DOWNLOAD_DIR` | path | `/downloads` | Base directory for downloaded files |
 | `TDL_FLAT_STRUCTURE` | boolean | `false` | Store all files in download dir without per-channel subfolders |
+| `TDL_TRACK_DOWNLOADS` | boolean | `true` | Track downloaded files to prevent re-downloads after move/rename |
 
 When `TDL_FLAT_STRUCTURE` is `false` (default), files are organized as `{download_dir}/{channel_name}/{filename}`. When `true`, all files go directly into `{download_dir}/{filename}`.
+
+When `TDL_TRACK_DOWNLOADS` is `true` (default), a persistent history of downloaded files is kept in the state database. This prevents re-downloading files that have been moved, renamed, or processed by external tools (e.g., media servers, Paperless-ngx, mergerfs). The tracking uses Telegram's `file_unique_id`, which is stable and unique per file content regardless of source. Set to `false` to disable and rely only on file-exists checks.
 
 ### Docker Environment
 
@@ -97,12 +100,14 @@ These are standard Docker environment variables, not prefixed with `TDL_`.
     - PGID=1000
     - TZ=Europe/Lisbon
     - TDL_FLAT_STRUCTURE=true
+    - TDL_TRACK_DOWNLOADS=true
     ```
 
 === "config.toml"
 
     ```toml
     flat_structure = true
+    track_downloads = true
     # PUID, PGID, and TZ are Docker-only (not in config.toml)
     ```
 
@@ -291,6 +296,7 @@ api_hash = "abcdef1234567890abcdef1234567890"
 phone_number = "+1234567890"
 download_dir = "/downloads"
 flat_structure = true
+track_downloads = true
 
 [daemon]
 enabled = true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -358,6 +358,41 @@ docker stats telegram-downloader
          cpus: '0.5'
    ```
 
+## Download Tracking
+
+### Files Re-Downloaded After Moving
+
+**Symptom:** Files you've already downloaded are being downloaded again after you move or rename them.
+
+**Cause:** Download tracking may be disabled, or the state database was deleted.
+
+**Solutions:**
+
+1. Ensure download tracking is enabled (it's on by default):
+   ```yaml
+   - TDL_TRACK_DOWNLOADS=true
+   ```
+2. Make sure the sessions volume is persisted — the download history lives in `state.db` alongside cursor data:
+   ```yaml
+   volumes:
+     - ./sessions:/app/.sessions
+   ```
+
+### Want to Re-Download Everything
+
+**Symptom:** You want to force re-download of all files (e.g., after a corrupted download).
+
+**Solutions:**
+
+1. Temporarily disable tracking:
+   ```yaml
+   - TDL_TRACK_DOWNLOADS=false
+   ```
+2. Or delete the state database to reset both cursors and download history:
+   ```bash
+   rm ./sessions/state.db
+   ```
+
 ## Getting Help
 
 !!! question "Still Stuck? Open an Issue"

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -43,6 +43,7 @@ BOOL_FIELDS = {
     "enabled",
     "allow_archives",
     "test_mode",
+    "track_downloads",
 }
 
 # Full field names that should be parsed as integers
@@ -85,6 +86,7 @@ FLAT_FIELDS = {
     "ebook_exts",
     "allow_archives",
     "archive_exts",
+    "track_downloads",
 }
 
 # Two-level nested fields (parent_child format)
@@ -117,7 +119,7 @@ def _parse_value(key: str, value: str) -> Any:
         return [v.strip() for v in value.split(",") if v.strip()]
 
     # Check if it's a boolean field
-    if field_name in BOOL_FIELDS:
+    if field_name in BOOL_FIELDS or key in BOOL_FIELDS:
         return value.lower() in ("true", "1", "yes", "on")
 
     # Check if it's an integer field (full match or suffix match)

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -110,6 +110,9 @@ class Config(BaseModel):
     # Storage structure
     flat_structure: bool = Field(default=False)
 
+    # Download tracking
+    track_downloads: bool = Field(default=True)
+
     # Logging
     verbosity: Literal["quiet", "normal", "verbose"] = Field(default="normal")
 

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ from src.config.schema import SourceConfig
 from src.config.source_parser import parse_sources, validate_source_access
 from src.organization import build_destination_path, is_duplicate, resolve_conflict
 from src.sources.base import BaseSource
-from src.state import CursorStore
+from src.state import CursorStore, DownloadHistory
 from src.client import create_client, download_media_with_retry
 from src.notifications import NotificationManager, DiscordNotifier, GenericWebhook
 
@@ -89,7 +89,8 @@ async def download_batch(
     config,
     log: logging.Logger,
     source: BaseSource,
-    source_config: SourceConfig
+    source_config: SourceConfig,
+    history: "DownloadHistory | None" = None,
 ) -> int:
     """Download a batch of messages concurrently with semaphore limit.
 
@@ -104,6 +105,7 @@ async def download_batch(
         log: Logger instance
         source: Source object for this batch
         source_config: Source configuration for folder naming
+        history: Optional download history for persistent deduplication
 
     Returns:
         Number of successfully downloaded files
@@ -125,6 +127,14 @@ async def download_batch(
                 msg.video_note
             )
             fname = getattr(media, "file_name", None) or f"message_{msg.id}"
+            media_size = getattr(media, "file_size", 0)
+
+            # Check download history for persistent deduplication
+            file_unique_id = getattr(media, "file_unique_id", None)
+            if history and file_unique_id and history.contains(file_unique_id):
+                log.info(f"Skip (already downloaded): {fname}")
+                cursor_store.set(cursor_key, msg.id)
+                return
 
             # Build organized destination path (includes per-source folder and validation)
             try:
@@ -142,7 +152,6 @@ async def download_batch(
 
             # Check for duplicates and resolve conflicts
             if dest.exists():
-                media_size = getattr(media, "file_size", 0)
                 if is_duplicate(dest, media_size):
                     log.info(f"Skip duplicate: {dest.name} (same size)")
                     cursor_store.set(cursor_key, msg.id)
@@ -173,6 +182,8 @@ async def download_batch(
             if success:
                 downloaded += 1
                 cursor_store.set(cursor_key, msg.id)
+                if history and file_unique_id:
+                    history.record(file_unique_id, fname, media_size, cursor_key, msg.id)
             else:
                 log.error(f"Failed to download: {dest.name}")
                 # Still update cursor to avoid getting stuck
@@ -238,7 +249,7 @@ async def startup_validation(cfg, log, client):
     return sources_with_filters
 
 
-async def run_check(cfg, log, state_store, client, sources_with_filters):
+async def run_check(cfg, log, state_store, client, sources_with_filters, history=None):
     """
     Single check iteration - process all configured sources.
 
@@ -251,6 +262,7 @@ async def run_check(cfg, log, state_store, client, sources_with_filters):
         state_store: CursorStore instance
         client: Pyrogram client instance
         sources_with_filters: Pre-parsed list of (source, filter_config) tuples
+        history: Optional DownloadHistory for persistent deduplication
     """
     # Create global concurrency control
     semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
@@ -315,7 +327,8 @@ async def run_check(cfg, log, state_store, client, sources_with_filters):
             cfg,
             log,
             source,
-            source_config
+            source_config,
+            history,
         )
 
         log.info(f"Downloaded {downloaded}/{len(candidates)} files")
@@ -336,6 +349,12 @@ async def main():
     if Path("/app/state.yaml").exists():
         log.info("Migrating state from YAML to SQLite...")
         state_store.migrate_from_yaml("/app/state.yaml")
+
+    # Initialize download history for persistent deduplication
+    history = None
+    if cfg.track_downloads:
+        history = DownloadHistory(str(state_db_path))
+        log.info("Download history tracking enabled")
 
     # Log credentials for debugging (mask sensitive parts)
     log.debug("=" * 50)
@@ -407,7 +426,7 @@ async def main():
                 # Do NOT re-parse sources in run_check - reuse startup_validation result
                 async def check_wrapper():
                     """Wrapper for run_check that captures sources_with_filters."""
-                    await run_check(cfg, log, state_store, client, sources_with_filters)
+                    await run_check(cfg, log, state_store, client, sources_with_filters, history)
 
                 service = DaemonService(
                     check_function=check_wrapper,
@@ -420,9 +439,11 @@ async def main():
                 await service.run()
             else:
                 log.info("Running in single-shot mode")
-                await run_check(cfg, log, state_store, client, sources_with_filters)
+                await run_check(cfg, log, state_store, client, sources_with_filters, history)
     finally:
         # Cleanup
+        if history:
+            history.close()
         state_store.close()
         log.info("Execution complete")
 

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -1,5 +1,6 @@
 """State management for download tracking."""
 
 from .cursor import CursorStore, StateError
+from .history import DownloadHistory
 
-__all__ = ["CursorStore", "StateError"]
+__all__ = ["CursorStore", "DownloadHistory", "StateError"]

--- a/src/state/history.py
+++ b/src/state/history.py
@@ -1,0 +1,153 @@
+"""SQLite-based download history for persistent deduplication.
+
+Tracks downloaded files by Telegram's file_unique_id to prevent re-downloads
+even after files are moved, renamed, or processed by external tools.
+Uses WAL mode for concurrent access alongside CursorStore on the same database.
+"""
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+from .cursor import StateError
+
+
+class DownloadHistory:
+    """Persistent download history using SQLite.
+
+    Features:
+    - Tracks files by Telegram's file_unique_id (stable, content-unique)
+    - WAL mode for concurrent access with CursorStore
+    - Retry logic for "database is locked" errors
+    - Integrity checking on initialization
+    """
+
+    def __init__(self, db_path: str):
+        """Initialize SQLite connection with WAL mode.
+
+        Args:
+            db_path: Path to SQLite database file
+
+        Raises:
+            StateError: If database is corrupted or initialization fails
+        """
+        self.db_path = db_path
+        self._connection: Optional[sqlite3.Connection] = None
+
+        # Create parent directory if needed
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        # Connect and initialize
+        self._connection = sqlite3.connect(db_path)
+
+        # Enable WAL mode for concurrent access
+        self._connection.execute("PRAGMA journal_mode=WAL")
+
+        # Check database integrity
+        result = self._connection.execute("PRAGMA integrity_check").fetchone()
+        if result[0] != "ok":
+            raise StateError(f"Database integrity check failed: {result[0]}")
+
+        # Create table if not exists
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS download_history (
+                file_unique_id TEXT PRIMARY KEY,
+                file_name TEXT NOT NULL,
+                file_size INTEGER NOT NULL,
+                source_key TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        self._connection.commit()
+
+    def contains(self, file_unique_id: str) -> bool:
+        """Check if a file has been previously downloaded.
+
+        Args:
+            file_unique_id: Telegram's stable unique file identifier
+
+        Returns:
+            True if file was previously downloaded
+        """
+        if not self._connection:
+            raise StateError("Database connection is closed")
+
+        cursor = self._connection.execute(
+            "SELECT 1 FROM download_history WHERE file_unique_id = ?",
+            (file_unique_id,)
+        )
+        return cursor.fetchone() is not None
+
+    def record(
+        self,
+        file_unique_id: str,
+        file_name: str,
+        file_size: int,
+        source_key: str,
+        message_id: int,
+    ) -> None:
+        """Record a downloaded file in history.
+
+        Uses UPSERT to handle re-recording the same file gracefully.
+        Implements retry logic for database locking errors.
+
+        Args:
+            file_unique_id: Telegram's stable unique file identifier
+            file_name: Original filename
+            file_size: File size in bytes
+            source_key: Source cursor key (e.g., "chat_123:topic_5")
+            message_id: Telegram message ID
+
+        Raises:
+            StateError: If all retry attempts exhausted or other database error
+        """
+        if not self._connection:
+            raise StateError("Database connection is closed")
+
+        max_retries = 3
+        delays = [0.1, 0.2, 0.4]  # Exponential backoff
+
+        for attempt in range(max_retries):
+            try:
+                self._connection.execute("BEGIN")
+                self._connection.execute("""
+                    INSERT INTO download_history
+                        (file_unique_id, file_name, file_size, source_key, message_id, downloaded_at)
+                    VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(file_unique_id) DO UPDATE SET
+                        file_name = excluded.file_name,
+                        file_size = excluded.file_size,
+                        source_key = excluded.source_key,
+                        message_id = excluded.message_id,
+                        downloaded_at = CURRENT_TIMESTAMP
+                """, (file_unique_id, file_name, file_size, source_key, message_id))
+                self._connection.commit()
+                return
+            except sqlite3.OperationalError as e:
+                self._connection.rollback()
+                if "database is locked" in str(e).lower() and attempt < max_retries - 1:
+                    time.sleep(delays[attempt])
+                    continue
+                raise StateError(f"Database operation failed: {e}")
+            except Exception as e:
+                self._connection.rollback()
+                raise StateError(f"Unexpected error during record: {e}")
+
+        raise StateError(f"Failed to record download after {max_retries} retries (database locked)")
+
+    def close(self) -> None:
+        """Close database connection."""
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - automatically close connection."""
+        self.close()
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,13 @@ class MockDocument:
         file_size: int = 1024000,
         mime_type: str = "application/pdf",
         file_id: str = "abc123",
+        file_unique_id: str = "unique_abc123",
     ):
         self.file_name = file_name
         self.file_size = file_size
         self.mime_type = mime_type
         self.file_id = file_id
+        self.file_unique_id = file_unique_id
 
 
 class MockMessage:
@@ -148,6 +150,12 @@ def memory_db(temp_dir):
     needs a file path for WAL mode and parent directory creation.
     """
     return str(temp_dir / "test_cursor.db")
+
+
+@pytest.fixture
+def history_db(temp_dir):
+    """Create a temporary SQLite database file path for DownloadHistory."""
+    return str(temp_dir / "test_history.db")
 
 
 # ============================================================================

--- a/tests/unit/config/test_schema.py
+++ b/tests/unit/config/test_schema.py
@@ -98,6 +98,17 @@ class TestConfig:
         with pytest.raises(ValidationError):
             Config.model_validate(minimal_config_dict)
 
+    def test_track_downloads_default_true(self, minimal_config_dict):
+        """track_downloads should default to True."""
+        config = Config.model_validate(minimal_config_dict)
+        assert config.track_downloads is True
+
+    def test_track_downloads_can_be_disabled(self, minimal_config_dict):
+        """track_downloads can be set to False."""
+        minimal_config_dict["track_downloads"] = False
+        config = Config.model_validate(minimal_config_dict)
+        assert config.track_downloads is False
+
     def test_max_concurrent_downloads_default(self, minimal_config_dict):
         """Default max_concurrent_downloads should be 1."""
         config = Config.model_validate(minimal_config_dict)

--- a/tests/unit/state/test_history.py
+++ b/tests/unit/state/test_history.py
@@ -1,0 +1,141 @@
+"""
+Unit tests for DownloadHistory (persistent download deduplication).
+
+Tests SQLite operations, WAL mode, context manager, coexistence with CursorStore.
+"""
+import pytest
+from pathlib import Path
+
+from src.state.cursor import CursorStore, StateError
+from src.state.history import DownloadHistory
+
+
+class TestDownloadHistoryBasics:
+    """Basic DownloadHistory operations."""
+
+    def test_create_history(self, history_db):
+        """DownloadHistory should create database file."""
+        history = DownloadHistory(history_db)
+        assert Path(history_db).exists()
+        history.close()
+
+    def test_creates_parent_directory(self, temp_dir):
+        """DownloadHistory should create parent directories if needed."""
+        nested_path = temp_dir / "nested" / "dir" / "history.db"
+        history = DownloadHistory(str(nested_path))
+        assert nested_path.exists()
+        history.close()
+
+    def test_contains_returns_false_for_unknown(self, history_db):
+        """contains() should return False for unknown file_unique_id."""
+        with DownloadHistory(history_db) as history:
+            assert history.contains("unknown_id") is False
+
+    def test_contains_returns_true_after_record(self, history_db):
+        """contains() should return True after recording a file."""
+        with DownloadHistory(history_db) as history:
+            history.record("unique_123", "test.pdf", 1024, "chat_1:topic_0", 42)
+            assert history.contains("unique_123") is True
+
+    def test_record_and_check_multiple_files(self, history_db):
+        """Should handle multiple independent file records."""
+        with DownloadHistory(history_db) as history:
+            history.record("id_a", "file_a.pdf", 100, "src_1", 1)
+            history.record("id_b", "file_b.epub", 200, "src_1", 2)
+            history.record("id_c", "file_c.mobi", 300, "src_2", 3)
+
+            assert history.contains("id_a") is True
+            assert history.contains("id_b") is True
+            assert history.contains("id_c") is True
+            assert history.contains("id_d") is False
+
+    def test_idempotent_re_recording(self, history_db):
+        """Recording the same file_unique_id twice should update, not fail."""
+        with DownloadHistory(history_db) as history:
+            history.record("unique_1", "old_name.pdf", 100, "src_1", 1)
+            # Re-record with different metadata (e.g., from a different source)
+            history.record("unique_1", "new_name.pdf", 100, "src_2", 5)
+            assert history.contains("unique_1") is True
+
+
+class TestDownloadHistoryContextManager:
+    """Context manager functionality."""
+
+    def test_context_manager_closes_connection(self, history_db):
+        """Context manager should close connection on exit."""
+        with DownloadHistory(history_db) as history:
+            history.record("test_id", "test.pdf", 100, "src", 1)
+        assert history._connection is None
+
+    def test_operations_after_close_raise_error(self, history_db):
+        """Operations after close should raise StateError."""
+        history = DownloadHistory(history_db)
+        history.close()
+
+        with pytest.raises(StateError):
+            history.contains("test")
+
+        with pytest.raises(StateError):
+            history.record("test", "f.pdf", 100, "src", 1)
+
+
+class TestDownloadHistoryPersistence:
+    """Data persistence across sessions."""
+
+    def test_data_persists_across_sessions(self, history_db):
+        """Data should persist when history is reopened."""
+        # First session: record download
+        with DownloadHistory(history_db) as history:
+            history.record("persist_id", "persist.pdf", 500, "src_1", 10)
+
+        # Second session: check it's still there
+        with DownloadHistory(history_db) as history:
+            assert history.contains("persist_id") is True
+            assert history.contains("other_id") is False
+
+
+class TestDownloadHistoryCoexistence:
+    """Coexistence with CursorStore on the same database."""
+
+    def test_shares_database_with_cursor_store(self, history_db):
+        """DownloadHistory and CursorStore can use the same database file."""
+        # Both open connections to the same DB
+        cursor_store = CursorStore(history_db)
+        history = DownloadHistory(history_db)
+
+        # Both should work independently
+        cursor_store.set("source_1", 100)
+        history.record("file_1", "test.pdf", 1024, "source_1", 100)
+
+        assert cursor_store.get("source_1") == 100
+        assert history.contains("file_1") is True
+
+        cursor_store.close()
+        history.close()
+
+
+class TestDownloadHistoryIntegrity:
+    """Database integrity and edge cases."""
+
+    def test_wal_mode_enabled(self, history_db):
+        """WAL mode should be enabled for concurrent access."""
+        with DownloadHistory(history_db) as history:
+            cursor = history._connection.execute("PRAGMA journal_mode")
+            mode = cursor.fetchone()[0]
+            assert mode.lower() == "wal"
+
+    def test_special_characters_in_filename(self, history_db):
+        """Should handle special characters in filenames."""
+        with DownloadHistory(history_db) as history:
+            special_names = [
+                "file with spaces.pdf",
+                "file'with'quotes.epub",
+                'file"double"quotes.mobi',
+                "файл_юникод.pdf",
+                "日本語ファイル.pdf",
+                "file (1) [copy].pdf",
+            ]
+            for i, name in enumerate(special_names):
+                uid = f"special_{i}"
+                history.record(uid, name, 100, "src", i)
+                assert history.contains(uid) is True


### PR DESCRIPTION
## Summary

Closes #22.

- Adds a persistent download history that tracks files by Telegram's `file_unique_id` (stable, unique per file content, available on all media types)
- Prevents re-downloads when files are moved, renamed, or processed by external tools (media servers, Paperless-ngx, mergerfs setups)
- Default ON, zero config needed for existing users — disable with `TDL_TRACK_DOWNLOADS=false`

### Changes

- **New**: `src/state/history.py` — `DownloadHistory` class (SQLite, WAL mode, shares `state.db` with `CursorStore`)
- **Config**: `track_downloads` bool field (default `true`), env var `TDL_TRACK_DOWNLOADS`
- **Main**: Early-exit skip in `download_one()` when `file_unique_id` found in history; record on success
- **Docs**: Configuration reference, troubleshooting guide, README updated
- **Tests**: 11 new tests for history (basics, persistence, coexistence, edge cases) + 2 schema tests

### Compatibility

- Existing users: history table created automatically on first run, empty history passes through to existing behavior
- Cursor + file-exists checks unchanged, remain as complementary mechanisms
- Same file across sources correctly de-duplicated (shared `file_unique_id`)

## Test plan

- [x] `pytest tests/` — all existing + new tests pass (189 passed, 1 pre-existing failure unrelated to this change)
- [ ] Manual: `track_downloads: true` → download files → move out of download dir → re-run → files NOT re-downloaded
- [ ] Manual: `track_downloads: false` → same scenario → files re-downloaded (current behavior)