### PR TITLE
fix: Clear-text logging of sensitive information

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -362,7 +362,11 @@ async def main():
     log.debug("=" * 50)
     log.debug(f"API ID: {cfg.api_id}")
     log.debug(f"API Hash: {cfg.api_hash[:8]}...{cfg.api_hash[-4:]}" if cfg.api_hash else "API Hash: None")
-    log.debug(f"Phone Number: {cfg.phone_number}")
+    masked_phone = None
+    if cfg.phone_number:
+        # Only log the last 4 digits to avoid exposing the full phone number
+        masked_phone = f"***{cfg.phone_number[-4:]}" if len(cfg.phone_number) >= 4 else "***"
+    log.debug(f"Phone Number: {masked_phone if masked_phone is not None else 'None'}")
     log.debug(f"Session Dir: {cfg.session_dir}")
     log.debug(f"Test Mode: {cfg.test_mode}")
     log.debug("=" * 50)


### PR DESCRIPTION
Potential fix for [https://github.com/rfsbraz/telegram-downloader/security/code-scanning/2](https://github.com/rfsbraz/telegram-downloader/security/code-scanning/2)

In general, sensitive data like phone numbers, tokens, and secrets should never be logged in clear text. Where logging is necessary for diagnostics, such data should either be omitted entirely or masked/partially redacted so that operators can still troubleshoot without exposing the full value.

Here, the best fix without changing overall functionality is to stop logging the full phone number and instead log a redacted version (e.g., last 2–4 digits only, or a simple placeholder indicating whether a phone number is configured). This preserves the “authentication debug info” purpose while removing clear-text exposure. Concretely, in `src/main.py` inside `main()`, replace the line that logs `cfg.phone_number` with a line that logs either a masked value or just whether a phone number is present. No new imports are needed; simple string operations suffice.

Specifically:
- In `src/main.py`, around line 365, change `log.debug(f"Phone Number: {cfg.phone_number}")` to something like:
  - `log.debug("Phone Number: [configured]")` if you only need to know that it exists, or
  - `log.debug(f"Phone Number: ***{cfg.phone_number[-4:]}")` if you want limited visibility, guarding for `None`.
- Ensure it handles the case where `cfg.phone_number` is `None` or empty to avoid exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
