### PR TITLE
docs: revamp README and update OSS files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,17 @@
 ## Summary
+
+<!-- What does this PR do? Keep it brief. -->
+
+## Type of Change
+
 - [ ] Bug fix
-- [ ] Feature
+- [ ] New feature
+- [ ] Refactoring (no functional changes)
 - [ ] Documentation
-- [ ] Maintenance
-
-## Description
-Describe what this PR changes. Include context and references to relevant issues or documentation.
-
-## Testing
-List the tests you ran and the results. Include commands, unit test names, or manual verification steps.
-- [ ] `pytest`
-- [ ] `docker compose up`
-- [ ] Other (specify below)
+- [ ] CI/CD or build
+- [ ] Dependencies
 
 ## Checklist
-- [ ] I updated documentation where necessary.
-- [ ] I added or updated tests to cover my changes.
-- [ ] I verified this change does not break existing functionality.
-- [ ] I have assigned reviewers or requested feedback as appropriate.
 
-## Additional Notes
-Add any follow-up steps, rollout considerations, or outstanding questions.
+- [ ] Tests pass (`make test`)
+- [ ] Documentation updated (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,248 +1,85 @@
-# Contributing to Telegram Media Downloader
+# Contributing
 
-Thank you for your interest in contributing! This document provides guidelines for contributing to the project.
-
-## Code of Conduct
-
-This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
-
-## How Can I Contribute?
-
-### Reporting Bugs
-
-Before creating bug reports, please check existing issues to avoid duplicates. When creating a bug report, include:
-
-- **Clear title and description**
-- **Steps to reproduce** the issue
-- **Expected vs actual behavior**
-- **Environment details** (OS, Python version, Docker version)
-- **Configuration** (redact sensitive information like API keys)
-- **Logs** (use `docker compose logs`)
-
-### Suggesting Enhancements
-
-Enhancement suggestions are welcome! Please include:
-
-- **Use case**: Why is this enhancement needed?
-- **Proposed solution**: How should it work?
-- **Alternatives considered**: What other approaches did you think about?
-
-### Pull Requests
-
-1. **Fork the repository** and create your branch from `master`
-2. **Make your changes** following the code style guidelines
-3. **Test your changes** thoroughly
-4. **Update documentation** if needed
-5. **Write clear commit messages** following the project's convention
-6. **Submit a pull request** with a comprehensive description
+Thanks for your interest in contributing! Here's everything you need to get started.
 
 ## Development Setup
 
-### Prerequisites
-
-- Python 3.11+
-- Docker and Docker Compose (for testing)
-- Git
-
-### Local Development
-
-1. **Clone your fork:**
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/telegram-downloader.git
-   cd telegram-downloader
-   ```
-
-2. **Create a virtual environment:**
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-3. **Install dependencies:**
-   ```bash
-   pip install -r requirements.txt
-   pip install -r requirements-dev.txt  # If exists
-   ```
-
-4. **Set up configuration:**
-   ```bash
-   cp config.example.toml config.toml  # If example exists
-   # Edit config.toml with your Telegram API credentials
-   ```
-
-5. **Run the application:**
-   ```bash
-   python -m telegram_downloader.main
-   ```
-
-### Testing
-
 ```bash
-# Run tests (when test suite exists)
-pytest
-
-# Run with coverage
-pytest --cov=telegram_downloader
-
-# Test Docker build
-docker build -t telegram-downloader-test .
-docker compose -f docker-compose.test.yml up  # If exists
+# Clone and install
+git clone https://github.com/rfsbraz/telegram-downloader.git
+cd telegram-downloader
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+pip install pytest pytest-cov pytest-asyncio
 ```
 
-### Documentation
-
-Documentation is built with MkDocs Material:
+### Running Tests
 
 ```bash
-# Install docs dependencies
+make test          # all tests with coverage
+make unit          # unit tests only
+make integration   # integration tests only
+```
+
+### Running Locally
+
+```bash
+make run           # builds Docker image + docker compose up
+# or
+docker compose up --build
+```
+
+### Building Docs
+
+```bash
 pip install -r requirements-docs.txt
-
-# Serve locally
-mkdocs serve
-
-# Build
-mkdocs build --strict
+mkdocs serve       # local preview at http://localhost:8000
 ```
 
-## Code Style Guidelines
+## Making Changes
 
-### Python Code
-
-- Follow [PEP 8](https://pep8.org/) style guide
-- Use type hints where appropriate
-- Write docstrings for public functions and classes
-- Keep functions focused and small
-- Use meaningful variable names
-
-**Example:**
-```python
-def download_media(
-    client: Client,
-    message: Message,
-    destination: Path
-) -> Optional[Path]:
-    """Download media from a Telegram message.
-
-    Args:
-        client: Pyrogram client instance
-        message: Message containing media
-        destination: Target download directory
-
-    Returns:
-        Path to downloaded file, or None if no media
-    """
-    # Implementation...
-```
+1. Fork the repository and create a branch from `main`
+2. Make your changes
+3. Run `make test` and make sure everything passes
+4. Update documentation if your change affects user-facing behavior
+5. Open a pull request
 
 ### Commit Messages
 
-Follow conventional commits format:
+Use [conventional commits](https://www.conventionalcommits.org/):
 
 ```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
+feat(filters): add regex pattern support
+fix(daemon): handle FloodWait gracefully
+docs: update configuration reference
+chore(deps): bump pyrogram
 ```
 
-**Types:**
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `refactor`: Code refactoring
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-
-**Examples:**
-```
-feat(filters): add regex pattern support for filename filtering
-
-Add ability to use regex patterns in addition to wildcards for more
-flexible filename matching.
-
-Closes #42
-```
-
-```
-fix(daemon): handle FloodWait errors gracefully
-
-Daemon now automatically retries after FloodWait with exponential
-backoff instead of crashing.
-
-Fixes #38
-```
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `perf`, `build`
 
 ## Project Structure
 
 ```
-telegram-downloader/
-├── src/
-│   └── telegram_downloader/
-│       ├── __init__.py
-│       ├── main.py              # Entry point
-│       ├── config.py            # Configuration management
-│       ├── client.py            # Telegram client wrapper
-│       ├── downloader.py        # Download logic
-│       ├── filters.py           # Message filters
-│       ├── sources.py           # Source implementations
-│       ├── organizer.py         # File organization
-│       ├── daemon.py            # Daemon service
-│       └── notifications.py     # Notification system
-├── docs/                        # MkDocs documentation
-├── examples/                    # Docker Compose examples
-├── tests/                       # Test suite
-├── .github/                     # GitHub templates and workflows
-├── Dockerfile                   # Multi-stage Docker build
-├── docker-compose.yml           # Docker Compose configuration
-├── requirements.txt             # Python dependencies
-├── requirements-docs.txt        # Documentation dependencies
-├── mkdocs.yml                   # MkDocs configuration
-└── README.md                    # Project overview
+src/
+  client/          # Telegram client and download logic
+  config/          # Configuration loading and validation
+  daemon/          # Daemon service and health checks
+  filters/         # Message filtering (extension, size, date, pattern)
+  notifications/   # Discord webhooks, HTTP POST
+  organization/    # File deduplication and path building
+  security/        # Filename sanitization
+  sources/         # Channel, group, forum topic, private chat
+  state/           # SQLite-backed cursor, download history, pending queue
+  main.py          # Entry point
+tests/
+  unit/            # Fast, no external dependencies
+  integration/     # Config loading, filter chains, healthcheck
+docs/              # MkDocs documentation
+examples/          # Docker Compose examples
 ```
-
-## Architecture Guidelines
-
-### Core Principles
-
-1. **Security First**: Always validate inputs, sanitize filenames, protect sessions
-2. **Fail Fast**: Validate configuration at startup, not during operation
-3. **Graceful Degradation**: Handle errors without crashing the daemon
-4. **Clean Architecture**: Separate concerns (config, download, organization, notification)
-
-### Key Design Patterns
-
-- **Factory Pattern**: Source factory creates appropriate source implementations
-- **Strategy Pattern**: Filters compose different matching strategies
-- **Repository Pattern**: State management abstraction over SQLite
-- **Observer Pattern**: Notifications observe download events
-
-## Testing Guidelines
-
-### What to Test
-
-- Configuration validation
-- Filter matching logic
-- File organization (sanitization, conflict resolution, duplicate detection)
-- Error handling (FloodWait, network errors, invalid sources)
-- State persistence across restarts
-
-### What Not to Test
-
-- External dependencies (Pyrogram, Telegram API)
-- Docker container behavior (covered by integration tests)
-
-## Documentation Guidelines
-
-- Update relevant documentation for any user-facing changes
-- Add examples for new features
-- Update configuration reference for new settings
-- Keep quickstart guide up-to-date
 
 ## Questions?
 
-- **General questions**: Use [GitHub Discussions](https://github.com/rfsbraz/telegram-downloader/discussions)
-- **Bug reports**: Open an [issue](https://github.com/rfsbraz/telegram-downloader/issues)
-- **Feature requests**: Open an [issue](https://github.com/rfsbraz/telegram-downloader/issues)
-
-Thank you for contributing! 🎉
+- **Bug reports and feature requests**: [Open an issue](https://github.com/rfsbraz/telegram-downloader/issues)
+- **General questions**: [GitHub Discussions](https://github.com/rfsbraz/telegram-downloader/discussions)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 
 A self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics. Configure once, run forever.
 
-[**Documentation**](https://rfsbraz.github.io/telegram-downloader/) · [**Quick Start**](#-quick-start) · [**Examples**](#-examples)
-
----
+[**Documentation**](https://rfsbraz.github.io/telegram-downloader/) | [**Quick Start**](#quick-start) | [**Examples**](#examples)
 
 ## Why?
 
@@ -19,7 +17,7 @@ Telegram is great for sharing files, but manually downloading from multiple sour
 - Filters by extension, size, date, or filename pattern
 - Organizes files into folders by source
 - Skips duplicates automatically
-- Tracks downloads persistently — files aren't re-downloaded after being moved or renamed
+- Tracks downloads persistently so files aren't re-downloaded after being moved or renamed
 - Sends notifications when downloads complete
 
 ## Features
@@ -39,16 +37,15 @@ Telegram is great for sharing files, but manually downloading from multiple sour
 
 - Docker and Docker Compose
 - Telegram API credentials from [my.telegram.org/apps](https://my.telegram.org/apps)
-- Telegram account with access to desired channels/groups
-- <img src=".github/images/channel-url.png" alt="The channel url" width="400">
-  
+- Telegram account with access to the channels/groups you want to download from
+
+<img src=".github/images/channel-url.png" alt="Where to find the channel URL" width="400">
+
 ### Setup
 
 ```bash
-# Create project directory
 mkdir telegram-downloader && cd telegram-downloader
 
-# Create docker-compose.yml
 cat > docker-compose.yml << 'EOF'
 services:
   telegram-downloader:
@@ -68,7 +65,6 @@ services:
     tty: true
 EOF
 
-# Start
 docker compose run --rm telegram-downloader
 ```
 
@@ -76,7 +72,7 @@ On first run, you'll be prompted for the Telegram verification code sent to your
 
 ## Configuration
 
-All configuration is done via environment variables with the `TDL_` prefix.
+All configuration is done via environment variables with the `TDL_` prefix. See the [full configuration reference](https://rfsbraz.github.io/telegram-downloader/configuration/) for all options.
 
 ### Sources
 
@@ -124,8 +120,8 @@ All configuration is done via environment variables with the `TDL_` prefix.
 
 ```yaml
 # User/group ID for file permissions (arr-stack compatible)
-- PUID=1000  # default: 1000
-- PGID=1000  # default: 1000
+- PUID=1000
+- PGID=1000
 
 # Timezone
 - TZ=Europe/Lisbon
@@ -133,12 +129,10 @@ All configuration is done via environment variables with the `TDL_` prefix.
 # Store all files in download_dir without per-channel subfolders
 - TDL_FLAT_STRUCTURE=true
 
-# Disable persistent download tracking (enabled by default)
+# Persistent download tracking (enabled by default)
 # When enabled, files won't be re-downloaded after being moved/renamed
 - TDL_TRACK_DOWNLOADS=true
 ```
-
-See the [full configuration reference](https://rfsbraz.github.io/telegram-downloader/configuration/) for all options.
 
 ## Examples
 
@@ -163,8 +157,6 @@ docker pull rfsbraz/telegram-downloader:latest
 docker pull ghcr.io/rfsbraz/telegram-downloader:latest
 ```
 
-### Tags
-
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
@@ -174,10 +166,7 @@ docker pull ghcr.io/rfsbraz/telegram-downloader:latest
 | `v1` | Latest minor for major version |
 | `sha-abc1234` | Specific commit |
 
-### Architectures
-
-- `linux/amd64` — Intel/AMD x86_64
-- `linux/arm64` — Raspberry Pi 4+, Apple Silicon, AWS Graviton
+Multi-arch: `linux/amd64` and `linux/arm64` (Raspberry Pi 4+, Apple Silicon, AWS Graviton).
 
 ## Troubleshooting
 
@@ -193,39 +182,31 @@ See the [troubleshooting guide](https://rfsbraz.github.io/telegram-downloader/tr
 ## Development
 
 ```bash
-# Clone
 git clone https://github.com/rfsbraz/telegram-downloader.git
 cd telegram-downloader
-
-# Install dependencies
 pip install -r requirements.txt
-
-# Run tests
-pytest tests/ -v
-
-# Build Docker image locally
-docker build -t telegram-downloader .
 ```
 
-## Contributing
+```bash
+make test          # all tests with coverage
+make unit          # unit tests only
+make integration   # integration tests only
+make build         # build Docker image
+make run           # build + docker compose up
+```
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit with conventional commits (`feat:`, `fix:`, `docs:`, etc.)
-4. Push and open a Pull Request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full development guidelines.
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT - see [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 
-- [Pyrogram](https://docs.pyrogram.org/) — Telegram MTProto API framework
-- [Pydantic](https://docs.pydantic.dev/) — Data validation
-- [docker/metadata-action](https://github.com/docker/metadata-action) — Docker tagging
+- [Pyrogram](https://docs.pyrogram.org/) - Telegram MTProto API framework
+- [Pydantic](https://docs.pydantic.dev/) - Data validation
+- [docker/metadata-action](https://github.com/docker/metadata-action) - Docker tagging
 
 ## ☕ Support
 
-If you find this useful and want to support development, you can [buy me a coffee](https://buymeacoffee.com/rfsbraz) — no pressure at all, just a nice way to say thanks.
+If you find this useful and want to support development, you can [buy me a coffee](https://buymeacoffee.com/rfsbraz) - no pressure at all, just a nice way to say thanks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,39 +1,44 @@
 # Security Policy
 
 ## Supported Versions
-Security fixes target the latest released version and the `main` branch. Older releases may receive fixes on a best-effort basis when the vulnerability is critical and the patch is low risk. If you maintain a fork, we recommend staying current with upstream updates.
+
+| Version | Supported |
+|---------|-----------|
+| latest release | Yes |
+| `edge` (main branch) | Best effort |
+| older releases | No |
+
+Security fixes target the latest release and `main`. Older releases may receive patches for critical vulnerabilities on a best-effort basis.
 
 ## Reporting a Vulnerability
-- Email the maintainer team at security@telegram-downloader.example (replace with your preferred contact) with the subject line "Security Report".
-- Include details to help reproduce the issue: affected version, configuration, logs, or proof-of-concept if possible.
-- If the vulnerability involves sensitive data, encrypt your report with the maintainer's public key if one is published.
-- Please allow up to 72 hours for an acknowledgement. If you receive no response, feel free to follow up.
 
-## Preferred Principles
-- Avoid opening public GitHub issues to report security vulnerabilities. Public reports will be converted to private discussions when feasible.
-- During responsible disclosure, keep details private until a fix is released and documented.
-- Provide a timeframe for coordinated disclosure if your policies require it; we generally aim to publish patches within 30 days.
+Please report security vulnerabilities through [GitHub Security Advisories](https://github.com/rfsbraz/telegram-downloader/security/advisories/new).
 
-## Coordinated Disclosure Process
-1. Maintainers acknowledge receipt of your report and begin investigation.
-2. A fix is developed, reviewed, and tested in private.
-3. You receive a pre-release advisory to confirm the fix and coordinate disclosure timing.
-4. The fix is released with a changelog entry and security advisory (if applicable).
-5. After publication, you are welcome to discuss the vulnerability publicly.
+- Include steps to reproduce, affected version, and impact assessment
+- Allow up to 72 hours for an initial response
+- Keep details private until a fix is released
 
 ## Scope
-Security reports should focus on:
+
 - Unauthorized access to user data or downloads
-- Remote code execution or privilege escalation within the application
+- Remote code execution or privilege escalation
 - Bypass of download filters or configuration restrictions
-- Insecure handling of credentials, tokens, or secrets
-- Container or deployment misconfigurations that materially weaken security
+- Insecure handling of credentials, tokens, or session files
+- Container misconfigurations that weaken security
 
 ## Out of Scope
-- Social engineering attacks on maintainers or contributors
-- Issues requiring physical access to the deployment environment
-- Dependencies with known vulnerabilities unless they impact practical exploitation of this project
-- Denial-of-service attacks that require unrealistic resources or rely on misconfigured infrastructure
 
-## Thank You
-We appreciate responsible disclosure and are happy to credit reporters in release notes unless anonymity is requested. Your efforts keep the Telegram Media Downloader community secure.
+- Social engineering attacks on maintainers
+- Issues requiring physical access to the host
+- Denial-of-service requiring unrealistic resources
+- Known dependency vulnerabilities without practical exploitation in this project
+
+## Disclosure Process
+
+1. You report the vulnerability privately
+2. We investigate and develop a fix
+3. You receive a pre-release advisory to confirm the fix
+4. Fix is released with a security advisory
+5. You're welcome to discuss the vulnerability publicly after release
+
+We're happy to credit reporters in release notes unless you prefer to remain anonymous.


### PR DESCRIPTION
## Summary

- Revamp README: cleaner structure, use `make` targets in dev section, remove redundant comments, fix em dashes
- Rewrite CONTRIBUTING.md: accurate project structure, correct paths and Python version, concise format
- Rewrite SECURITY.md: proper supported versions table, use GitHub Security Advisories instead of placeholder email
- Simplify PR template: lightweight checklist without testing/notes boilerplate