### PR TITLE
ci(release): use PAT instead of GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,11 @@ jobs:
       version: ${{ steps.release.outputs.version }}
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Replace GitHub App token generation with a PAT (`RELEASE_PLEASE_TOKEN`) for release-please authentication
- Removes the `actions/create-github-app-token` step and associated `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` references