### PR TITLE
fix(daemon): timezone-aware health timestamps and heartbeat

### DIFF
--- a/healthcheck.py
+++ b/healthcheck.py
@@ -12,11 +12,11 @@ Line 2: ISO timestamp of last update
 """
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 
 HEALTH_FILE = Path(os.getenv("TDL_DAEMON_HEALTH_FILE", "/app/health_status.txt"))
-MAX_AGE_SECONDS = 600  # 10 minutes
+MAX_AGE_SECONDS = int(os.getenv("TDL_DAEMON_HEALTH_MAX_AGE", "600"))
 
 def main():
     # Check if health file exists
@@ -41,8 +41,12 @@ def main():
             print(f"Invalid timestamp: {timestamp_str}", file=sys.stderr)
             sys.exit(1)
 
+        # Older daemons wrote naive timestamps, which were always UTC
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+
         # Check if status is stale
-        age = datetime.now() - timestamp
+        age = datetime.now(timezone.utc) - timestamp
         if age.total_seconds() > MAX_AGE_SECONDS:
             print(f"Health status stale ({age.total_seconds():.0f}s old)", file=sys.stderr)
             sys.exit(1)

--- a/src/daemon/health.py
+++ b/src/daemon/health.py
@@ -1,7 +1,8 @@
 """Health status monitoring for daemon process."""
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ class HealthMonitor:
             health_file: Path to health status file (e.g., /app/health_status.txt)
         """
         self.health_file = health_file
+        self._last_status: Optional[str] = None
 
     def update_status(self, status: str) -> None:
         """
@@ -38,10 +40,27 @@ class HealthMonitor:
         """
         try:
             self._write_health_file(status)
+            self._last_status = status
             logger.info(f"Health status: {status}")
         except Exception as e:
             # Log error but don't crash - health check failure is better than daemon crash
             logger.error(f"Failed to write health status: {e}")
+
+    def heartbeat(self) -> None:
+        """
+        Refresh the health file timestamp without changing status.
+
+        Keeps the health file fresh during long check iterations and idle
+        periods between checks, so staleness detection only fires when the
+        daemon is genuinely stuck.
+        """
+        if self._last_status is None:
+            return
+        try:
+            self._write_health_file(self._last_status)
+            logger.debug(f"Health heartbeat: {self._last_status}")
+        except Exception as e:
+            logger.error(f"Failed to write health heartbeat: {e}")
 
     def _write_health_file(self, status: str) -> None:
         """
@@ -60,8 +79,8 @@ class HealthMonitor:
         # Ensure parent directory exists
         self.health_file.parent.mkdir(parents=True, exist_ok=True)
 
-        # Prepare content with timestamp
-        timestamp = datetime.utcnow().isoformat()
+        # Prepare content with timezone-aware UTC timestamp
+        timestamp = datetime.now(timezone.utc).isoformat()
         content = f"{status}\n{timestamp}\n"
 
         # Atomic write: temp file + rename

--- a/src/daemon/service.py
+++ b/src/daemon/service.py
@@ -39,6 +39,8 @@ class DaemonService:
         during startup will fail-fast and prevent daemon from starting.
     """
 
+    HEARTBEAT_INTERVAL = 60  # seconds between health file timestamp refreshes
+
     def __init__(
         self,
         check_function: Callable[[], Awaitable[None]],
@@ -65,6 +67,7 @@ class DaemonService:
         self.health = HealthMonitor(health_file)
         self.log = logging.getLogger("daemon")
         self.iteration = 0
+        self._heartbeat_task: Optional[asyncio.Task] = None
 
     async def startup(self):
         """
@@ -236,6 +239,25 @@ class DaemonService:
                     }
                 )
 
+    async def _heartbeat_loop(self):
+        """
+        Refresh the health file timestamp at a fixed interval.
+
+        Runs for the daemon's entire lifetime so the health file stays fresh
+        both during long check iterations and while sleeping between checks.
+        Without this, any check_interval (or single check) longer than the
+        healthcheck staleness window would mark a healthy daemon unhealthy.
+        """
+        while not self.shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self.shutdown_event.wait(),
+                    timeout=self.HEARTBEAT_INTERVAL
+                )
+                break  # Shutdown triggered
+            except asyncio.TimeoutError:
+                self.health.heartbeat()
+
     async def periodic_loop(self):
         """
         Main daemon loop with periodic execution.
@@ -317,10 +339,15 @@ class DaemonService:
             # Startup initialization and validation
             await self.startup()
 
+            # Keep health file timestamp fresh during and between checks
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
             # Main periodic loop
             await self.periodic_loop()
 
         finally:
+            if self._heartbeat_task and not self._heartbeat_task.done():
+                self._heartbeat_task.cancel()
             # Ensure cleanup happens even if exceptions occur
             if not self.shutdown_event.is_set():
                 await self.shutdown()

--- a/tests/integration/test_healthcheck.py
+++ b/tests/integration/test_healthcheck.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import os
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -26,7 +26,7 @@ class TestHealthcheckExitCodes:
     def test_healthy_status_exits_zero(self, temp_dir, monkeypatch):
         """Healthy status should exit with code 0."""
         health_file = temp_dir / "health_status.txt"
-        health_file.write_text(f"healthy\n{datetime.now().isoformat()}")
+        health_file.write_text(f"healthy\n{datetime.now(timezone.utc).isoformat()}")
 
         env = os.environ.copy()
         env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
@@ -44,7 +44,7 @@ class TestHealthcheckExitCodes:
     def test_starting_status_exits_zero(self, temp_dir, monkeypatch):
         """Starting status should also exit with code 0."""
         health_file = temp_dir / "health_status.txt"
-        health_file.write_text(f"starting\n{datetime.now().isoformat()}")
+        health_file.write_text(f"starting\n{datetime.now(timezone.utc).isoformat()}")
 
         env = os.environ.copy()
         env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
@@ -61,7 +61,7 @@ class TestHealthcheckExitCodes:
     def test_error_status_exits_one(self, temp_dir, monkeypatch):
         """Error status should exit with code 1."""
         health_file = temp_dir / "health_status.txt"
-        health_file.write_text(f"error\n{datetime.now().isoformat()}")
+        health_file.write_text(f"error\n{datetime.now(timezone.utc).isoformat()}")
 
         env = os.environ.copy()
         env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
@@ -99,7 +99,7 @@ class TestHealthcheckStaleness:
         health_file = temp_dir / "health_status.txt"
 
         # Timestamp more than 10 minutes ago
-        old_timestamp = datetime.now() - timedelta(minutes=15)
+        old_timestamp = datetime.now(timezone.utc) - timedelta(minutes=15)
         health_file.write_text(f"healthy\n{old_timestamp.isoformat()}")
 
         env = os.environ.copy()
@@ -114,6 +114,72 @@ class TestHealthcheckStaleness:
 
         assert result.returncode == 1
         assert "stale" in result.stderr.lower()
+
+
+class TestHealthcheckTimezones:
+    """Timezone handling in staleness detection."""
+
+    def test_legacy_naive_utc_timestamp_is_accepted(self, temp_dir, monkeypatch):
+        """Naive timestamps (old daemon format) are interpreted as UTC."""
+        health_file = temp_dir / "health_status.txt"
+
+        # Old daemons wrote datetime.utcnow().isoformat() (naive UTC)
+        naive_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+        health_file.write_text(f"healthy\n{naive_utc.isoformat()}")
+
+        env = os.environ.copy()
+        env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
+
+        result = subprocess.run(
+            [sys.executable, str(HEALTHCHECK_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+
+    def test_fresh_aware_timestamp_not_stale_regardless_of_local_tz(
+        self, temp_dir, monkeypatch
+    ):
+        """An aware UTC timestamp written now must never read as stale."""
+        health_file = temp_dir / "health_status.txt"
+        health_file.write_text(
+            f"healthy\n{datetime.now(timezone.utc).isoformat()}"
+        )
+
+        env = os.environ.copy()
+        env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
+        # Force a non-UTC timezone for the healthcheck process
+        env["TZ"] = "Europe/Lisbon"
+
+        result = subprocess.run(
+            [sys.executable, str(HEALTHCHECK_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+
+    def test_max_age_configurable_via_env(self, temp_dir, monkeypatch):
+        """TDL_DAEMON_HEALTH_MAX_AGE overrides the default staleness window."""
+        health_file = temp_dir / "health_status.txt"
+        old_timestamp = datetime.now(timezone.utc) - timedelta(minutes=15)
+        health_file.write_text(f"healthy\n{old_timestamp.isoformat()}")
+
+        env = os.environ.copy()
+        env["TDL_DAEMON_HEALTH_FILE"] = str(health_file)
+        env["TDL_DAEMON_HEALTH_MAX_AGE"] = "3600"
+
+        result = subprocess.run(
+            [sys.executable, str(HEALTHCHECK_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
 
 
 class TestHealthcheckFileFormat:

--- a/tests/unit/daemon/test_health.py
+++ b/tests/unit/daemon/test_health.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for HealthMonitor (health status file management).
+
+Tests timezone-aware timestamps, status updates, and heartbeat refresh.
+"""
+from datetime import datetime, timezone
+
+from src.daemon.health import HealthMonitor
+
+
+class TestHealthMonitorTimestamps:
+    """Timestamp format written to the health file."""
+
+    def test_writes_timezone_aware_utc_timestamp(self, temp_dir):
+        """Health file timestamps must be timezone-aware UTC."""
+        health_file = temp_dir / "health_status.txt"
+        monitor = HealthMonitor(health_file)
+        monitor.update_status("healthy")
+
+        lines = health_file.read_text().strip().split("\n")
+        assert lines[0] == "healthy"
+
+        timestamp = datetime.fromisoformat(lines[1])
+        assert timestamp.tzinfo is not None
+        age = (datetime.now(timezone.utc) - timestamp).total_seconds()
+        assert 0 <= age < 60
+
+
+class TestHealthMonitorHeartbeat:
+    """Heartbeat refreshes timestamp without changing status."""
+
+    def test_heartbeat_refreshes_timestamp_keeps_status(self, temp_dir):
+        """heartbeat() rewrites the file with the same status."""
+        health_file = temp_dir / "health_status.txt"
+        monitor = HealthMonitor(health_file)
+        monitor.update_status("healthy")
+
+        first_timestamp = health_file.read_text().strip().split("\n")[1]
+
+        monitor.heartbeat()
+        lines = health_file.read_text().strip().split("\n")
+        assert lines[0] == "healthy"
+        # Timestamp refreshed (or at minimum still valid and parseable)
+        refreshed = datetime.fromisoformat(lines[1])
+        assert refreshed >= datetime.fromisoformat(first_timestamp)
+
+    def test_heartbeat_before_first_status_is_noop(self, temp_dir):
+        """heartbeat() before any update_status() must not create the file."""
+        health_file = temp_dir / "health_status.txt"
+        monitor = HealthMonitor(health_file)
+        monitor.heartbeat()
+        assert not health_file.exists()
+
+    def test_heartbeat_preserves_error_status(self, temp_dir):
+        """heartbeat() must not mask an error status."""
+        health_file = temp_dir / "health_status.txt"
+        monitor = HealthMonitor(health_file)
+        monitor.update_status("error")
+        monitor.heartbeat()
+
+        lines = health_file.read_text().strip().split("\n")
+        assert lines[0] == "error"


### PR DESCRIPTION
## Summary

- Fix timezone mismatch between the health file writer and `healthcheck.py`: the daemon wrote naive UTC timestamps (`datetime.utcnow()`) while the healthcheck compared against naive local time (`datetime.now()`). On hosts east of UTC every health file looked hours old, so containers were flagged unhealthy and restart-looped; west of UTC the age went negative and staleness detection silently never fired. Both sides now use timezone-aware UTC.
- Add a daemon heartbeat that refreshes the health file timestamp every 60s for the daemon's entire lifetime. Previously the file was only touched once per check iteration, so any check longer than 10 minutes (e.g., a large initial sync) or a `check_interval` above 600s tripped the staleness check on a perfectly healthy daemon.
- Naive timestamps from older daemon versions are still accepted and interpreted as UTC, so mixed-version upgrades keep working.
- Make the staleness window configurable via `TDL_DAEMON_HEALTH_MAX_AGE` (default unchanged at 600s).
- Add unit tests for `HealthMonitor` (aware timestamps, heartbeat semantics) and integration tests covering legacy naive timestamps, non-UTC local timezones, and the new env override.