### PR TITLE
fix(downloads): prevent concurrent same-name collisions and cursor regression

### DIFF
--- a/src/client/downloader.py
+++ b/src/client/downloader.py
@@ -18,6 +18,7 @@ from pyrogram.types import Message
 from pyrogram.errors import FloodWait, FileReferenceExpired
 
 from src.config.schema import Config
+from src.organization.deduplicator import is_duplicate, resolve_conflict
 
 
 async def download_media_with_retry(
@@ -70,8 +71,12 @@ async def download_media_with_retry(
     # Create parent directories if needed
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Use temporary .partial file during download
-    dest_temp = dest_path.with_suffix(dest_path.suffix + ".partial")
+    # Use temporary .partial file during download. The message ID makes the
+    # temp name unique so concurrent downloads of same-named files never
+    # stream into the same file.
+    dest_temp = dest_path.with_suffix(
+        dest_path.suffix + f".{message.id}.partial"
+    )
 
     # Progress callback for streaming (writes chunks without buffering entire file)
     def progress_callback(current: int, total: int) -> None:
@@ -154,6 +159,20 @@ async def download_media_with_retry(
                             f"{dest_path.name} ({actual_size}/{expected_size} bytes)"
                         )
                         return False
+
+            # Re-check for conflicts at rename time: a concurrent download may
+            # have created dest_path since the caller's pre-download check
+            if dest_path.exists():
+                if is_duplicate(dest_path, dest_temp.stat().st_size):
+                    dest_temp.unlink()
+                    log.info(
+                        f"Skip duplicate at rename: {dest_path.name} "
+                        "(same size, downloaded concurrently)"
+                    )
+                    return True
+                resolved = resolve_conflict(dest_path)
+                log.info(f"Conflict at rename: {dest_path.name} → {resolved.name}")
+                dest_path = resolved
 
             # Atomic rename on success (prevents partial files in download dir)
             dest_temp.rename(dest_path)

--- a/src/state/cursor.py
+++ b/src/state/cursor.py
@@ -84,9 +84,12 @@ class CursorStore:
         return row[0] if row else default
 
     def set(self, source_key: str, message_id: int) -> None:
-        """Set cursor value for a source with atomic transaction.
+        """Advance cursor value for a source with atomic transaction.
 
-        Uses UPSERT (INSERT OR REPLACE) to handle both new and existing keys.
+        The cursor is monotonic: setting a value lower than the stored one is
+        a no-op. Downloads complete out of order under concurrency, so without
+        this guard the last writer would win and the cursor could move
+        backwards, causing already-processed messages to be rescanned.
         Implements retry logic for database locking errors.
 
         Args:
@@ -109,7 +112,7 @@ class CursorStore:
                     INSERT INTO cursors (source_key, last_message_id, updated_at)
                     VALUES (?, ?, CURRENT_TIMESTAMP)
                     ON CONFLICT(source_key) DO UPDATE SET
-                        last_message_id = excluded.last_message_id,
+                        last_message_id = MAX(last_message_id, excluded.last_message_id),
                         updated_at = CURRENT_TIMESTAMP
                 """, (source_key, message_id))
                 self._connection.commit()

--- a/tests/unit/client/test_downloader.py
+++ b/tests/unit/client/test_downloader.py
@@ -43,6 +43,87 @@ def client():
     return AsyncMock()
 
 
+class TestConcurrencySafety:
+    """Temp file uniqueness and rename-time conflict handling."""
+
+    @pytest.mark.asyncio
+    async def test_partial_file_name_includes_message_id(
+        self, client, message, dest_path, log
+    ):
+        """Temp files must be unique per message so concurrent downloads of
+        same-named files never share a .partial file."""
+        config = make_config(max_retries=1)
+        seen_paths = []
+
+        async def fake_download(msg, file_name, progress=None):
+            seen_paths.append(file_name)
+            p = Path(file_name)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"content")
+
+        client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = await download_media_with_retry(
+            client, message, dest_path, config, log
+        )
+
+        assert result is True
+        assert f".{message.id}.partial" in seen_paths[0]
+
+    @pytest.mark.asyncio
+    async def test_same_size_file_at_rename_is_skipped_as_duplicate(
+        self, client, message, dest_path, log
+    ):
+        """If an identical file appeared at dest during download, keep it."""
+        config = make_config(max_retries=1)
+
+        async def fake_download(msg, file_name, progress=None):
+            p = Path(file_name)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"same content")
+            # Simulate a concurrent task completing the same file first
+            dest_path.write_bytes(b"same content")
+
+        client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = await download_media_with_retry(
+            client, message, dest_path, config, log
+        )
+
+        assert result is True
+        assert dest_path.read_bytes() == b"same content"
+        # No conflict copy created
+        assert not (dest_path.parent / "test_file_2.pdf").exists()
+        # Temp file cleaned up
+        assert not list(dest_path.parent.glob("*.partial"))
+
+    @pytest.mark.asyncio
+    async def test_different_file_at_rename_resolves_conflict(
+        self, client, message, dest_path, log
+    ):
+        """If a different file appeared at dest during download, keep both."""
+        config = make_config(max_retries=1)
+
+        async def fake_download(msg, file_name, progress=None):
+            p = Path(file_name)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"new download content")
+            # Simulate a concurrent task writing a different file to dest
+            dest_path.write_bytes(b"other")
+
+        client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = await download_media_with_retry(
+            client, message, dest_path, config, log
+        )
+
+        assert result is True
+        assert dest_path.read_bytes() == b"other"
+        conflict_copy = dest_path.parent / "test_file_2.pdf"
+        assert conflict_copy.exists()
+        assert conflict_copy.read_bytes() == b"new download content"
+
+
 class TestZeroByteValidation:
     """Tests for zero-byte download detection and retry."""
 

--- a/tests/unit/state/test_cursor.py
+++ b/tests/unit/state/test_cursor.py
@@ -54,6 +54,20 @@ class TestCursorStoreBasics:
             store.set("test_source", 200)
             assert store.get("test_source") == 200
 
+    def test_set_is_monotonic(self, memory_db):
+        """set() must never move the cursor backwards.
+
+        Concurrent downloads complete out of order; a lower message ID
+        finishing last must not regress the cursor.
+        """
+        with CursorStore(memory_db) as store:
+            store.set("test_source", 300)
+            store.set("test_source", 100)
+            assert store.get("test_source") == 300
+
+            store.set("test_source", 400)
+            assert store.get("test_source") == 400
+
     def test_multiple_sources(self, memory_db):
         """Should handle multiple source keys independently."""
         with CursorStore(memory_db) as store:


### PR DESCRIPTION
## Summary

- Fix a data corruption race with `max_concurrent_downloads > 1`: two messages carrying the same filename in one batch both passed the pre-download conflict check (neither file existed yet) and then streamed into the **same** `.partial` file concurrently. Temp files now include the message ID (`name.ext.<msg_id>.partial`) so every download writes to its own file.
- Re-check the destination at rename time: if a concurrent download created the destination meanwhile, a same-size file is treated as a duplicate (temp discarded, success) and a different file gets a `_2` conflict name instead of being clobbered.
- Make cursor updates monotonic in `CursorStore.set`: downloads complete out of order, so the last writer could previously regress the cursor to a lower message ID, causing already-processed ranges to be rescanned and re-queued on the next run.
- Unit tests cover temp file uniqueness, duplicate-at-rename, conflict-at-rename, and cursor monotonicity.