### PR TITLE
fix(config): tolerate gaps in TDL_SOURCES_N numbering

### DIFF
--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -230,6 +230,22 @@ def _load_from_env() -> dict | None:
         # Fallback: treat as simple key
         data[key_path] = parsed_value
 
+    # Compact the sources list: gaps in TDL_SOURCES_N_* numbering (e.g. a
+    # commented-out source in the middle) leave empty placeholder entries
+    # behind, which would otherwise fail validation with a confusing
+    # "Either url or chat_id must be provided" error. Drop them and keep
+    # the remaining sources in their original order.
+    if "sources" in data:
+        original_count = len(data["sources"])
+        data["sources"] = [s for s in data["sources"] if s]
+        dropped = original_count - len(data["sources"])
+        if dropped:
+            import logging
+            logging.getLogger(__name__).warning(
+                f"Ignoring {dropped} gap(s) in TDL_SOURCES_N_* numbering; "
+                f"{len(data['sources'])} source(s) configured"
+            )
+
     return data
 
 

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -121,6 +121,31 @@ class TestLoadFromEnv:
         assert result["sources"][0]["url"] == "https://t.me/channel1"
         assert result["sources"][1]["url"] == "https://t.me/channel2"
 
+    def test_sources_array_with_gap(self, clean_env, monkeypatch):
+        """Gaps in source numbering should be compacted, not left as empty entries."""
+        monkeypatch.setenv("TDL_API_ID", "12345")
+        monkeypatch.setenv("TDL_API_HASH", "abc123")
+        monkeypatch.setenv("TDL_SOURCES_0_URL", "https://t.me/channel1")
+        # Source 1 disabled/commented out - gap in numbering
+        monkeypatch.setenv("TDL_SOURCES_2_URL", "https://t.me/channel3")
+
+        result = _load_from_env()
+        assert len(result["sources"]) == 2
+        assert result["sources"][0]["url"] == "https://t.me/channel1"
+        assert result["sources"][1]["url"] == "https://t.me/channel3"
+
+    def test_sources_array_one_based(self, clean_env, monkeypatch):
+        """1-based source numbering should work (index 0 pad entry dropped)."""
+        monkeypatch.setenv("TDL_API_ID", "12345")
+        monkeypatch.setenv("TDL_API_HASH", "abc123")
+        monkeypatch.setenv("TDL_SOURCES_1_URL", "https://t.me/channel1")
+        monkeypatch.setenv("TDL_SOURCES_2_URL", "https://t.me/channel2")
+
+        result = _load_from_env()
+        assert len(result["sources"]) == 2
+        assert result["sources"][0]["url"] == "https://t.me/channel1"
+        assert result["sources"][1]["url"] == "https://t.me/channel2"
+
     def test_sources_with_filters(self, clean_env, monkeypatch):
         """Source filters should be parsed correctly."""
         monkeypatch.setenv("TDL_API_ID", "12345")


### PR DESCRIPTION
Fixes #41

- Gaps in `TDL_SOURCES_N_*` numbering (e.g. a commented-out source in the middle, or 1-based numbering) left empty placeholder entries in the parsed sources list, which then failed validation with `Either url or chat_id must be provided` and crash-looped the container
- Compact those empty placeholder entries out of the list after env parsing, keeping the remaining sources in order, and log how many gaps were ignored
- Add regression tests for gapped and 1-based numbering