### PR TITLE
fix(sources): skip unresolvable sources instead of crash-looping

### DIFF
--- a/src/config/source_parser.py
+++ b/src/config/source_parser.py
@@ -5,12 +5,13 @@ Parses source configuration into Source instances with filter composition,
 handling global filter defaults and per-source overrides.
 """
 
+import logging
 from typing import Optional
 
 from pyrogram import Client
 
 from src.config.loader import ConfigError
-from src.config.schema import Config, GlobalFilters
+from src.config.schema import Config, GlobalFilters, SourceConfig
 from src.config.url_parser import parse_telegram_url
 from src.filters import (
     CompositeFilter,
@@ -21,6 +22,8 @@ from src.filters import (
 )
 from src.sources.base import BaseSource
 from src.sources.factory import create_source
+
+logger = logging.getLogger("downloader")
 
 
 def parse_size(size_str: str) -> int:
@@ -169,29 +172,36 @@ def build_filters(filter_config: GlobalFilters) -> CompositeFilter:
 async def parse_sources(
     config: Config,
     client: Client
-) -> list[tuple[BaseSource, CompositeFilter]]:
+) -> list[tuple[BaseSource, CompositeFilter, SourceConfig]]:
     """
     Parse sources from configuration and create Source instances with filters.
 
     For each source:
     1. Resolves URL or chat_id to Source instance via factory
     2. Builds CompositeFilter by merging global and per-source filters
-    3. Returns list of (source, filter) tuples
+    3. Returns list of (source, filter, source_config) tuples
+
+    Configuration errors (missing url/chat_id, invalid URL, bad filter
+    values) fail fast with ConfigError - they need a config fix.
+    Telegram-side resolution failures (deleted/renamed channel, ban,
+    network issues) only skip that source with an error log, so one dead
+    source doesn't take down the remaining ones (issue #40).
 
     Args:
         config: Configuration with sources list
         client: Authenticated Pyrogram client
 
     Returns:
-        List of (BaseSource, CompositeFilter) tuples
+        List of (BaseSource, CompositeFilter, SourceConfig) tuples for
+        the sources that could be resolved
 
     Raises:
-        ConfigError: If source configuration is invalid
-        ValueError: If URL parsing or source creation fails
+        ConfigError: If source configuration itself is invalid
     """
     results = []
 
     for idx, source_config in enumerate(config.sources):
+        # --- Configuration parsing: fail fast on invalid config ---
         try:
             # Determine chat_id and topic_id
             chat_id = None
@@ -210,9 +220,6 @@ async def parse_sources(
                 raise ConfigError(
                     f"Source {idx + 1}: Either url or chat_id must be provided"
                 )
-
-            # Create source instance via factory
-            source_instance = await create_source(client, chat_id, topic_id)
 
             # Build filters: merge global with per-source overrides
             if source_config.filters:
@@ -238,39 +245,57 @@ async def parse_sources(
                 # Use global filters
                 composite_filter = build_filters(config.global_filters)
 
-            results.append((source_instance, composite_filter))
-
+        except ConfigError:
+            raise
         except Exception as e:
             # Wrap exceptions with source context
             raise ConfigError(
                 f"Failed to parse source {idx + 1}: {e}"
             )
 
+        # --- Telegram resolution: skip this source on failure ---
+        label = source_config.url or source_config.chat_id
+        try:
+            source_instance = await create_source(client, chat_id, topic_id)
+        except Exception as e:
+            logger.error(
+                f"Source {idx + 1} ({label}) could not be resolved: {e} - "
+                f"skipping this source. Remove or fix it in your configuration."
+            )
+            continue
+
+        results.append((source_instance, composite_filter, source_config))
+
     return results
 
 
 async def validate_source_access(
-    sources: list[BaseSource],
+    sources_with_filters: list[tuple[BaseSource, CompositeFilter, SourceConfig]],
     client: Client
-) -> None:
+) -> list[tuple[BaseSource, CompositeFilter, SourceConfig]]:
     """
-    Validate that all sources are accessible at startup.
+    Validate source accessibility at startup, keeping only usable sources.
 
     Attempts to get chat info for each source to ensure:
     - Chat exists and is accessible
     - User has permission to access chat
     - Chat ID is valid
 
-    Fails fast if any source is inaccessible.
+    Inaccessible sources are skipped with a clear error log instead of
+    aborting the whole run, so one dead source doesn't block the rest
+    (issue #40).
 
     Args:
-        sources: List of BaseSource instances to validate
+        sources_with_filters: (source, filter, source_config) tuples to validate
         client: Authenticated Pyrogram client
 
-    Raises:
-        ConfigError: If any source is inaccessible with clear error message
+    Returns:
+        The subset of tuples whose sources are accessible
     """
-    for idx, source in enumerate(sources):
+    accessible = []
+
+    for idx, entry in enumerate(sources_with_filters):
+        source = entry[0]
         try:
             # Try to get chat info
             await client.get_chat(source.chat_id)
@@ -279,23 +304,20 @@ async def validate_source_access(
 
             # Detect specific error types and provide helpful messages
             if "peer_id_invalid" in error_msg or "peer id invalid" in error_msg:
-                raise ConfigError(
-                    f"Source {idx + 1} (chat_id={source.chat_id}): "
-                    f"Invalid chat ID. Chat may not exist or you haven't interacted with it."
-                )
+                reason = "Invalid chat ID. Chat may not exist or you haven't interacted with it."
             elif "user_not_participant" in error_msg or "not a participant" in error_msg:
-                raise ConfigError(
-                    f"Source {idx + 1} (chat_id={source.chat_id}): "
-                    f"You are not a member of this chat. Join the chat first."
-                )
+                reason = "You are not a member of this chat. Join the chat first."
             elif "chat_forbidden" in error_msg or "forbidden" in error_msg:
-                raise ConfigError(
-                    f"Source {idx + 1} (chat_id={source.chat_id}): "
-                    f"Access forbidden. You may have been banned or removed."
-                )
+                reason = "Access forbidden. You may have been banned or removed."
             else:
-                # Generic error
-                raise ConfigError(
-                    f"Source {idx + 1} (chat_id={source.chat_id}): "
-                    f"Cannot access chat: {e}"
-                )
+                reason = f"Cannot access chat: {e}"
+
+            logger.error(
+                f"Source {idx + 1} (chat_id={source.chat_id}): {reason} "
+                f"- skipping this source."
+            )
+            continue
+
+        accessible.append(entry)
+
+    return accessible

--- a/src/main.py
+++ b/src/main.py
@@ -210,14 +210,14 @@ async def startup_validation(cfg, log, client):
     - Source accessibility (parse_sources + validate_source_access)
 
     Returns:
-        sources_with_filters: List of (source, filter_config) tuples for run_check
+        sources_with_filters: List of (source, filter, source_config) tuples
+        for run_check. Sources that cannot be resolved or accessed are
+        skipped with an error log (issue #40); startup only fails if NO
+        source is usable.
 
     Raises:
-        ConfigError: Configuration validation failed
-        RuntimeError: Telegram auth or source access failed
-
-    BLOCKER 2 FIX: validate_source_access() exceptions propagate unchanged.
-    RuntimeError indicates source inaccessibility (fail-fast behavior).
+        ConfigError: Configuration validation failed or no usable sources
+        RuntimeError: Telegram auth failed
 
     BLOCKER 3 FIX: Parse sources once here, return sources_with_filters.
     main() stores result and passes to run_check via closure.
@@ -241,13 +241,21 @@ async def startup_validation(cfg, log, client):
     # Parse and validate sources (BLOCKER 3 FIX: parse once, return result)
     log.info("Validating configured sources...")
     sources_with_filters = await parse_sources(cfg, client)
-    sources = [s for s, _ in sources_with_filters]
+    sources_with_filters = await validate_source_access(sources_with_filters, client)
 
-    # BLOCKER 2 FIX: Let validate_source_access exceptions propagate
-    # RuntimeError from validate_source_access indicates source inaccessibility
-    # This is fail-fast behavior - startup should fail if sources are inaccessible
-    await validate_source_access(sources, client)
-    log.info(f"All {len(sources)} source(s) accessible")
+    configured = len(cfg.sources)
+    usable = len(sources_with_filters)
+    if usable == 0:
+        raise ConfigError(
+            f"None of the {configured} configured source(s) are accessible. "
+            f"Check the errors above and fix your configuration."
+        )
+    if usable < configured:
+        log.warning(
+            f"{configured - usable} of {configured} source(s) skipped as "
+            f"unresolvable/inaccessible - see errors above"
+        )
+    log.info(f"{usable} source(s) accessible")
 
     return sources_with_filters
 
@@ -264,22 +272,15 @@ async def run_check(cfg, log, state_store, client, sources_with_filters, history
         log: Logger instance
         state_store: CursorStore instance
         client: Pyrogram client instance
-        sources_with_filters: Pre-parsed list of (source, filter_config) tuples
+        sources_with_filters: Pre-parsed list of (source, filter, source_config) tuples
         history: Optional DownloadHistory for persistent deduplication
         pending: Optional PendingDownloads queue for resumable downloads
     """
     # Create global concurrency control
     semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
 
-    # Build mapping: cursor_key -> source_config for folder naming
-    source_config_map: dict[str, SourceConfig] = {}
-    for idx, (source, _) in enumerate(sources_with_filters):
-        cursor_key = source.get_cursor_key()
-        # Use same index to get corresponding source config
-        source_config_map[cursor_key] = cfg.sources[idx]
-
     # Iterate sources sequentially (config order = priority)
-    for source, composite_filter in sources_with_filters:
+    for source, composite_filter, source_config in sources_with_filters:
         cursor_key = source.get_cursor_key()
         last_seen_id = state_store.get(cursor_key, 0)
 
@@ -291,12 +292,6 @@ async def run_check(cfg, log, state_store, client, sources_with_filters, history
         log.info("=" * 60)
 
         max_downloads = cfg.max_downloads_per_run or 0
-
-        # Look up source_config early (needed for download_batch)
-        source_config = source_config_map.get(cursor_key)
-        if source_config is None:
-            log.error(f"No source config found for cursor key: {cursor_key}")
-            continue
 
         # --- Scan phase: stream IDs into pending ---
         if pending and pending.has_pending(cursor_key):

--- a/tests/unit/config/test_source_parser.py
+++ b/tests/unit/config/test_source_parser.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for source parsing and access validation.
+
+Covers the skip-instead-of-crash behavior for unresolvable sources
+(issue #40): one dead channel must not abort the remaining sources.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.config.loader import ConfigError
+from src.config.schema import Config
+from src.config.source_parser import parse_sources, validate_source_access
+
+
+def make_config(sources: list[dict]) -> Config:
+    """Build a minimal valid Config with the given sources."""
+    return Config.model_validate({
+        "api_id": 12345,
+        "api_hash": "abc123",
+        "sources": sources,
+    })
+
+
+def make_chat(chat_id: int):
+    """Mock Chat object resolved by client.get_chat."""
+    from pyrogram.enums import ChatType
+
+    chat = MagicMock()
+    chat.id = chat_id
+    chat.type = ChatType.CHANNEL
+    return chat
+
+
+class TestParseSources:
+    """Tests for parse_sources resolution behavior."""
+
+    async def test_all_sources_resolve(self):
+        config = make_config([
+            {"url": "https://t.me/channel_one"},
+            {"url": "https://t.me/channel_two"},
+        ])
+        client = MagicMock()
+        client.get_chat = AsyncMock(side_effect=[make_chat(-100111), make_chat(-100222)])
+
+        results = await parse_sources(config, client)
+
+        assert len(results) == 2
+        # Tuples carry the matching source config (no index misalignment)
+        assert results[0][2] is config.sources[0]
+        assert results[1][2] is config.sources[1]
+
+    async def test_dead_source_is_skipped_not_fatal(self):
+        """A username that no longer exists must not abort the other sources."""
+        config = make_config([
+            {"url": "https://t.me/alive_channel"},
+            {"url": "https://t.me/dead_channel"},
+            {"url": "https://t.me/another_alive"},
+        ])
+        client = MagicMock()
+        client.get_chat = AsyncMock(side_effect=[
+            make_chat(-100111),
+            Exception("[400 USERNAME_NOT_OCCUPIED] - The username is not occupied by anyone"),
+            make_chat(-100333),
+        ])
+
+        results = await parse_sources(config, client)
+
+        assert len(results) == 2
+        assert results[0][2] is config.sources[0]
+        assert results[1][2] is config.sources[2]
+
+    async def test_missing_url_and_chat_id_still_fails_fast(self):
+        """A structurally invalid source is a config error, not a skip."""
+        config = make_config([{"name": "no url or chat_id"}])
+        client = MagicMock()
+        client.get_chat = AsyncMock()
+
+        with pytest.raises(ConfigError, match="url or chat_id"):
+            await parse_sources(config, client)
+
+
+class TestValidateSourceAccess:
+    """Tests for validate_source_access filtering behavior."""
+
+    def _entry(self, chat_id: int):
+        source = MagicMock()
+        source.chat_id = chat_id
+        return (source, MagicMock(), MagicMock())
+
+    async def test_all_accessible(self):
+        entries = [self._entry(-100111), self._entry(-100222)]
+        client = MagicMock()
+        client.get_chat = AsyncMock(side_effect=[make_chat(-100111), make_chat(-100222)])
+
+        accessible = await validate_source_access(entries, client)
+
+        assert accessible == entries
+
+    async def test_inaccessible_source_is_filtered_out(self):
+        entries = [self._entry(-100111), self._entry(-100222), self._entry(-100333)]
+        client = MagicMock()
+        client.get_chat = AsyncMock(side_effect=[
+            make_chat(-100111),
+            Exception("CHAT_FORBIDDEN"),
+            make_chat(-100333),
+        ])
+
+        accessible = await validate_source_access(entries, client)
+
+        assert accessible == [entries[0], entries[2]]


### PR DESCRIPTION
Fixes #40

- A single dead source (deleted/renamed channel, `USERNAME_NOT_OCCUPIED`, ban, etc.) aborted startup with exit 1, so the container crash-looped and the remaining sources were never scanned
- `parse_sources` now only fails fast on genuine configuration errors (missing url/chat_id, invalid URL, bad filter values); Telegram-side resolution failures log a clear error and skip that source
- `validate_source_access` now filters out inaccessible sources with the same per-source error messages instead of raising; startup only fails when zero sources remain usable
- Source tuples now carry their own `SourceConfig`, removing the index-based `source_config_map` in `run_check` that would have silently misaligned configs once sources can be skipped
- Add unit tests covering skip, fail-fast, and filtering behavior