### PR TITLE
feat(hooks): run configurable command after each successful download

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ All configuration is done via environment variables with the `TDL_` prefix. See 
 - TDL_DAEMON_CHECK_INTERVAL=300  # seconds between checks
 ```
 
+### Post-Download Hook
+
+Run a command after each successful download - extract archives, convert
+formats, trigger library scans, move files to watch folders:
+
+```yaml
+- TDL_POST_DOWNLOAD_HOOK=unrar x "{file}" "{dir}"
+- TDL_POST_DOWNLOAD_HOOK_TIMEOUT=300  # seconds, default 300
+```
+
+Available placeholders: `{file}` (absolute path), `{dir}` (parent directory),
+`{filename}`, `{extension}`, `{source}` (source display name), `{size}` (bytes).
+
+The command runs without a shell (filenames can't inject arguments) and a
+hook failure never marks the download as failed.
+
 ### Notifications
 
 ```yaml

--- a/src/client/hooks.py
+++ b/src/client/hooks.py
@@ -1,0 +1,129 @@
+"""Post-download hook execution.
+
+Runs a user-configured shell command after each successful download,
+enabling integration with external tools (unrar, ffmpeg, library scans)
+without modifying the downloader itself.
+
+Security model: the command template is split with shlex FIRST, then
+placeholder values are substituted into the resulting tokens verbatim.
+Filenames can never inject additional arguments or shell syntax, and no
+shell is involved (subprocess exec, shell=False).
+"""
+
+import asyncio
+import logging
+import shlex
+from pathlib import Path
+
+# Supported placeholders in the hook command template
+PLACEHOLDERS = ("file", "dir", "filename", "extension", "source", "size")
+
+
+def build_hook_command(
+    template: str,
+    file_path: Path,
+    source_name: str,
+    size: int,
+) -> list[str]:
+    """Build the argv list for a hook command template.
+
+    The template is tokenized first (shlex), then placeholders are
+    replaced inside each token, so values containing spaces or quotes
+    stay a single argument and cannot inject extra ones.
+
+    Args:
+        template: Command template, e.g. 'unrar x "{file}" "{dir}"'
+        file_path: Absolute path of the downloaded file
+        source_name: Display name of the source
+        size: File size in bytes
+
+    Returns:
+        argv list ready for subprocess execution (empty if template is blank)
+    """
+    values = {
+        "file": str(file_path),
+        "dir": str(file_path.parent),
+        "filename": file_path.name,
+        "extension": file_path.suffix,
+        "source": source_name,
+        "size": str(size),
+    }
+
+    argv = []
+    for token in shlex.split(template):
+        for name in PLACEHOLDERS:
+            token = token.replace("{" + name + "}", values[name])
+        argv.append(token)
+    return argv
+
+
+async def run_post_download_hook(
+    template: str,
+    file_path: Path,
+    source_name: str,
+    size: int,
+    timeout: int,
+    log: logging.Logger,
+) -> None:
+    """Run the post-download hook for a downloaded file.
+
+    Hook failures (bad command, non-zero exit, timeout) are logged but
+    never raised: the file was already saved successfully, so the
+    download must not be marked as failed because of the hook.
+
+    Args:
+        template: Command template with placeholders
+        file_path: Absolute path of the downloaded file
+        source_name: Display name of the source
+        size: File size in bytes
+        timeout: Max seconds to wait for the hook before killing it
+        log: Logger instance
+    """
+    try:
+        argv = build_hook_command(template, file_path, source_name, size)
+    except ValueError as e:
+        log.warning(f"Post-download hook has invalid syntax: {e}")
+        return
+
+    if not argv:
+        return
+
+    log.debug(f"Running post-download hook for {file_path.name}: {argv}")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except Exception as e:
+        log.warning(f"Post-download hook failed to start for {file_path.name}: {e}")
+        return
+
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        log.warning(
+            f"Post-download hook timed out after {timeout}s for {file_path.name}"
+        )
+        return
+    except Exception as e:
+        log.warning(f"Post-download hook failed for {file_path.name}: {e}")
+        return
+
+    if stdout:
+        log.debug(f"Hook stdout: {stdout.decode(errors='replace').strip()}")
+    if stderr:
+        log.debug(f"Hook stderr: {stderr.decode(errors='replace').strip()}")
+
+    if process.returncode != 0:
+        log.warning(
+            f"Post-download hook exited with code {process.returncode} "
+            f"for {file_path.name}"
+        )
+    else:
+        log.debug(f"Post-download hook completed for {file_path.name}")

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -61,7 +61,7 @@ INT_FIELDS = {
 }
 
 # Field name endings that indicate integers (for nested fields)
-INT_SUFFIXES = {"_id", "_interval", "_seconds", "_downloads", "_retries", "_delay"}
+INT_SUFFIXES = {"_id", "_interval", "_seconds", "_downloads", "_retries", "_delay", "_timeout"}
 
 # Top-level fields that should NOT be nested (underscore is part of name)
 FLAT_FIELDS = {
@@ -87,6 +87,8 @@ FLAT_FIELDS = {
     "allow_archives",
     "archive_exts",
     "track_downloads",
+    "post_download_hook",
+    "post_download_hook_timeout",
 }
 
 # Two-level nested fields (parent_child format)

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -113,6 +113,11 @@ class Config(BaseModel):
     # Download tracking
     track_downloads: bool = Field(default=True)
 
+    # Post-download hook: shell command run after each successful download.
+    # Supports placeholders: {file}, {dir}, {filename}, {extension}, {source}, {size}
+    post_download_hook: Optional[str] = None
+    post_download_hook_timeout: int = Field(default=300, ge=1, le=86400)
+
     # Logging
     verbosity: Literal["quiet", "normal", "verbose"] = Field(default="normal")
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.organization import build_destination_path, is_duplicate, resolve_confl
 from src.sources.base import BaseSource
 from src.state import CursorStore, DownloadHistory, PendingDownloads
 from src.client import create_client, download_media_with_retry
+from src.client.hooks import run_post_download_hook
 from src.notifications import NotificationManager, DiscordNotifier, GenericWebhook
 
 
@@ -188,6 +189,20 @@ async def download_batch(
                 cursor_store.set(cursor_key, msg.id)
                 if history and file_unique_id:
                     history.record(file_unique_id, fname, media_size, cursor_key, msg.id)
+
+                # Post-download hook (issue #35) - failures are logged but
+                # never mark the download as failed (the file is already saved)
+                if config.post_download_hook:
+                    source_name = source_config.name or await source.get_display_name()
+                    actual_size = dest.stat().st_size if dest.exists() else media_size
+                    await run_post_download_hook(
+                        config.post_download_hook,
+                        dest,
+                        source_name,
+                        actual_size,
+                        config.post_download_hook_timeout,
+                        log,
+                    )
             else:
                 log.error(f"Failed to download: {dest.name}")
                 failed_ids.add(msg.id)

--- a/tests/unit/client/test_hooks.py
+++ b/tests/unit/client/test_hooks.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for post-download hooks (issue #35).
+
+Covers placeholder substitution, injection safety, execution,
+timeout handling, and the never-fail contract.
+"""
+import logging
+import sys
+from pathlib import Path
+
+from src.client.hooks import build_hook_command, run_post_download_hook
+
+log = logging.getLogger("test-hooks")
+
+
+class TestBuildHookCommand:
+    """Tests for command template parsing and substitution."""
+
+    def test_all_placeholders(self):
+        file_path = Path("/downloads/Books/story.pdf")
+        argv = build_hook_command(
+            'process "{file}" "{dir}" {filename} {extension} "{source}" {size}',
+            file_path=file_path,
+            source_name="My Channel",
+            size=1024,
+        )
+        assert argv == [
+            "process",
+            str(file_path),
+            str(file_path.parent),
+            "story.pdf",
+            ".pdf",
+            "My Channel",
+            "1024",
+        ]
+
+    def test_filename_with_spaces_stays_one_argument(self):
+        file_path = Path("/downloads/my great archive.rar")
+        argv = build_hook_command(
+            'unrar x "{file}" "{dir}"',
+            file_path=file_path,
+            source_name="src",
+            size=1,
+        )
+        assert argv == ["unrar", "x", str(file_path), str(file_path.parent)]
+
+    def test_malicious_filename_cannot_inject_arguments(self):
+        """A filename containing shell syntax stays a single literal argument."""
+        evil = Path('/downloads/x"; rm -rf / #.pdf')
+        argv = build_hook_command('touch "{file}"', evil, "src", 1)
+        assert argv == ["touch", str(evil)]
+
+    def test_empty_template_yields_empty_argv(self):
+        assert build_hook_command("", Path("/f.pdf"), "src", 1) == []
+
+
+class TestRunPostDownloadHook:
+    """Tests for hook execution semantics."""
+
+    async def test_successful_hook_runs(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        # Use forward slashes so the template survives POSIX-mode shlex
+        # on Windows test runs too
+        py = Path(sys.executable).as_posix()
+        template = (
+            f'"{py}" -c '
+            f'"import pathlib,sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2])" '
+            f'"{marker.as_posix()}" "{{filename}}"'
+        )
+        await run_post_download_hook(
+            template, tmp_path / "book.pdf", "src", 42, timeout=30, log=log
+        )
+        assert marker.read_text() == "book.pdf"
+
+    async def test_nonzero_exit_does_not_raise(self, tmp_path):
+        template = f'"{Path(sys.executable).as_posix()}" -c "import sys; sys.exit(3)"'
+        # Must not raise
+        await run_post_download_hook(
+            template, tmp_path / "book.pdf", "src", 1, timeout=30, log=log
+        )
+
+    async def test_missing_command_does_not_raise(self, tmp_path):
+        await run_post_download_hook(
+            "definitely-not-a-real-command-xyz {file}",
+            tmp_path / "book.pdf", "src", 1, timeout=30, log=log,
+        )
+
+    async def test_timeout_kills_hook_and_does_not_raise(self, tmp_path):
+        template = f'"{Path(sys.executable).as_posix()}" -c "import time; time.sleep(60)"'
+        await run_post_download_hook(
+            template, tmp_path / "book.pdf", "src", 1, timeout=1, log=log
+        )
+
+    async def test_invalid_syntax_does_not_raise(self, tmp_path):
+        # Unbalanced quote is a shlex ValueError
+        await run_post_download_hook(
+            'echo "{file}', tmp_path / "book.pdf", "src", 1, timeout=30, log=log
+        )


### PR DESCRIPTION
Fixes #35

- New `TDL_POST_DOWNLOAD_HOOK` setting runs a command after each successful download, with `{file}`, `{dir}`, `{filename}`, `{extension}`, `{source}` and `{size}` placeholders
- `TDL_POST_DOWNLOAD_HOOK_TIMEOUT` (default 300s) kills hung hooks
- Injection-safe by construction: the template is tokenized first, placeholders are substituted into tokens afterwards, and the process runs without a shell - filenames can never add arguments or shell syntax
- Hook stdout/stderr logged at DEBUG, non-zero exits and timeouts at WARNING; a hook failure never marks the download as failed
- Unit tests cover substitution, injection safety, execution, timeout and the never-fail contract; README documents the feature