### PR TITLE
feat(daemon): download scheduling windows and bandwidth throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ All configuration is done via environment variables with the `TDL_` prefix. See 
 - TDL_DAEMON_CHECK_INTERVAL=300  # seconds between checks
 ```
 
+### Scheduling & Bandwidth
+
+Control when checks run and how fast downloads go - useful for metered
+connections or shared networks:
+
+```yaml
+# Only run download checks inside these windows (24h, local time via TZ).
+# Multiple windows and cross-midnight windows are supported.
+- TDL_SCHEDULE_ACTIVE_HOURS=02:00-08:00,22:00-23:59
+
+# Cap aggregate download speed across all concurrent downloads
+- TDL_MAX_DOWNLOAD_SPEED=5MB
+```
+
+Outside active hours the daemon stays alive (health checks keep passing)
+but skips download checks. A download already in flight when a window
+closes is never interrupted. Both settings default to unrestricted.
+
 ### Notifications
 
 ```yaml

--- a/src/client/downloader.py
+++ b/src/client/downloader.py
@@ -18,6 +18,7 @@ from pyrogram.types import Message
 from pyrogram.errors import FloodWait, FileReferenceExpired
 
 from src.config.schema import Config
+from src.client.ratelimit import RateLimiter
 
 
 async def download_media_with_retry(
@@ -27,6 +28,7 @@ async def download_media_with_retry(
     config: Config,
     log: logging.Logger,
     expected_size: int = 0,
+    limiter: "RateLimiter | None" = None,
 ) -> bool:
     """Download media with streaming, retry logic, and FloodWait handling.
 
@@ -54,6 +56,7 @@ async def download_media_with_retry(
         config: Configuration with retry settings
         log: Logger instance for progress/error reporting
         expected_size: Expected file size in bytes (for logging context)
+        limiter: Optional shared RateLimiter capping aggregate download speed
 
     Returns:
         True if download succeeded, False if all retries exhausted
@@ -73,8 +76,10 @@ async def download_media_with_retry(
     # Use temporary .partial file during download
     dest_temp = dest_path.with_suffix(dest_path.suffix + ".partial")
 
-    # Progress callback for streaming (writes chunks without buffering entire file)
-    def progress_callback(current: int, total: int) -> None:
+    # Track cumulative progress so the rate limiter sees byte deltas
+    progress_state = {"last": 0}
+
+    def _log_progress(current: int, total: int) -> None:
         """Log download progress at intervals."""
         if total > 0:
             percent = (current / total) * 100
@@ -82,8 +87,23 @@ async def download_media_with_retry(
             if int(percent) % 10 == 0 and int(percent) > 0:
                 log.debug(f"Download progress: {percent:.1f}% ({current}/{total} bytes)")
 
+    if limiter:
+        # Async callback: pyrogram awaits coroutine progress callbacks, so
+        # the limiter can sleep without blocking the event loop
+        async def progress_callback(current: int, total: int) -> None:
+            delta = current - progress_state["last"]
+            progress_state["last"] = current
+            if delta > 0:
+                await limiter.throttle(delta)
+            _log_progress(current, total)
+    else:
+        def progress_callback(current: int, total: int) -> None:
+            _log_progress(current, total)
+
     # Main download loop with retry logic
     for attempt in range(1, config.max_retries + 1):
+        # Each attempt restarts the transfer from zero
+        progress_state["last"] = 0
         try:
             # Stream download to temporary file
             await client.download_media(

--- a/src/client/ratelimit.py
+++ b/src/client/ratelimit.py
@@ -1,0 +1,95 @@
+"""Bandwidth rate limiting for downloads.
+
+Token-bucket limiter shared by all concurrent downloads. Pyrogram
+reports cumulative progress per file; the download progress callback
+feeds byte deltas into the limiter, which sleeps just long enough to
+keep the aggregate download rate at or below the configured cap.
+"""
+
+import asyncio
+import re
+import time as time_module
+
+# Rate units (binary multiples, matching the size filters)
+_RATE_UNITS = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024 ** 2,
+    "GB": 1024 ** 3,
+}
+
+_RATE_RE = re.compile(r"^([\d.]+)\s*([A-Z]+)?(?:/S)?$")
+
+
+def parse_rate(rate_str: str) -> int:
+    """Parse a human-readable rate string to bytes per second.
+
+    Supports "500KB", "5MB", "1.5MB", optionally suffixed with "/s".
+
+    Args:
+        rate_str: Rate string with unit suffix
+
+    Returns:
+        Rate in bytes per second
+
+    Raises:
+        ValueError: If the format is invalid or the rate is not positive
+    """
+    match = _RATE_RE.match(rate_str.strip().upper())
+    if not match:
+        raise ValueError(
+            f"Invalid download speed: '{rate_str}'. "
+            f"Expected format: '500KB', '5MB', etc."
+        )
+
+    number_str, unit = match.groups()
+    unit = unit or "B"
+    if unit not in _RATE_UNITS:
+        raise ValueError(
+            f"Unknown speed unit: '{unit}'. "
+            f"Supported units: {', '.join(_RATE_UNITS)}"
+        )
+
+    rate = float(number_str) * _RATE_UNITS[unit]
+    if rate <= 0:
+        raise ValueError(f"Download speed must be positive: '{rate_str}'")
+    return int(rate)
+
+
+class RateLimiter:
+    """Async token-bucket rate limiter shared across concurrent downloads.
+
+    Tokens (bytes) accrue at `rate` per second up to a burst of one
+    second's worth. Consumers call `throttle(nbytes)` after receiving
+    a chunk; when the bucket runs dry the caller sleeps just long
+    enough for the average rate to converge to the cap.
+    """
+
+    def __init__(self, rate: int):
+        """
+        Args:
+            rate: Maximum aggregate rate in bytes per second
+        """
+        self.rate = rate
+        self._allowance = float(rate)  # start with one second of burst
+        self._last = time_module.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def throttle(self, nbytes: int) -> None:
+        """Account for `nbytes` transferred; sleep if over the cap."""
+        if nbytes <= 0:
+            return
+
+        async with self._lock:
+            now = time_module.monotonic()
+            self._allowance = min(
+                float(self.rate),
+                self._allowance + (now - self._last) * self.rate,
+            )
+            self._last = now
+            self._allowance -= nbytes
+            # Deficit determines how long to wait for the bucket to refill
+            wait = -self._allowance / self.rate if self._allowance < 0 else 0.0
+
+        if wait > 0:
+            await asyncio.sleep(wait)

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -74,6 +74,8 @@ FLAT_FIELDS = {
     "log_file",
     "state_file",
     "verbosity",
+    "schedule_active_hours",
+    "max_download_speed",
     "max_concurrent_downloads",
     "max_downloads_per_run",
     "max_retries",

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -121,6 +121,15 @@ class Config(BaseModel):
     global_filters: GlobalFilters = Field(default_factory=GlobalFilters)
     max_concurrent_downloads: int = Field(default=1, ge=1, le=10)
 
+    # Scheduling: only run download checks inside these windows (daemon mode).
+    # 24h format, comma-separated, may cross midnight: "02:00-08:00,22:00-23:59"
+    # Empty means no restriction.
+    schedule_active_hours: str = Field(default="")
+
+    # Bandwidth: cap aggregate download speed ("500KB", "5MB").
+    # Empty means unlimited.
+    max_download_speed: str = Field(default="")
+
     # Daemon mode configuration
     daemon: DaemonConfig = Field(default_factory=DaemonConfig)
 
@@ -150,6 +159,32 @@ class Config(BaseModel):
     def validate_sources(cls, v: list[SourceConfig]) -> list[SourceConfig]:
         """Ensure sources list is not empty if provided."""
         # Allow empty list for backward compatibility with legacy config
+        return v
+
+    @field_validator("schedule_active_hours")
+    @classmethod
+    def validate_schedule_active_hours(cls, v: str) -> str:
+        """Fail fast on malformed active-hours windows."""
+        if v:
+            # Function-level import to avoid a config <-> daemon import cycle
+            from src.daemon.schedule import parse_active_hours
+            try:
+                parse_active_hours(v)
+            except ValueError as e:
+                raise ValueError(str(e))
+        return v
+
+    @field_validator("max_download_speed")
+    @classmethod
+    def validate_max_download_speed(cls, v: str) -> str:
+        """Fail fast on malformed download speed values."""
+        if v:
+            # Function-level import to avoid a config <-> client import cycle
+            from src.client.ratelimit import parse_rate
+            try:
+                parse_rate(v)
+            except ValueError as e:
+                raise ValueError(str(e))
         return v
 
     @field_validator("api_hash")

--- a/src/daemon/schedule.py
+++ b/src/daemon/schedule.py
@@ -1,0 +1,85 @@
+"""Time-window scheduling for download checks.
+
+Parses active-hours specifications like "02:00-08:00" or
+"02:00-08:00,22:00-23:59" (local time via TZ) and answers whether the
+current time falls inside any configured window. Windows may cross
+midnight (e.g. "23:00-06:00").
+"""
+
+import re
+from datetime import datetime, time
+
+# One window: HH:MM-HH:MM
+_WINDOW_RE = re.compile(r"^(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})$")
+
+
+def parse_active_hours(spec: str) -> list[tuple[time, time]]:
+    """Parse an active-hours spec into a list of (start, end) windows.
+
+    Args:
+        spec: Comma-separated windows in 24h format, e.g.
+            "02:00-08:00" or "02:00-08:00,22:00-23:59".
+            Windows may cross midnight ("23:00-06:00").
+
+    Returns:
+        List of (start, end) datetime.time tuples (empty for blank spec)
+
+    Raises:
+        ValueError: If any window has an invalid format or out-of-range values
+    """
+    windows = []
+
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+
+        match = _WINDOW_RE.match(part)
+        if not match:
+            raise ValueError(
+                f"Invalid active hours window: '{part}'. "
+                f"Expected 24h format like '02:00-08:00'."
+            )
+
+        h1, m1, h2, m2 = (int(g) for g in match.groups())
+        if not (0 <= h1 <= 23 and 0 <= h2 <= 23 and 0 <= m1 <= 59 and 0 <= m2 <= 59):
+            raise ValueError(
+                f"Invalid active hours window: '{part}'. "
+                f"Hours must be 00-23 and minutes 00-59."
+            )
+
+        windows.append((time(h1, m1), time(h2, m2)))
+
+    return windows
+
+
+def is_within_active_hours(
+    windows: list[tuple[time, time]],
+    now: time | None = None,
+) -> bool:
+    """Check whether `now` falls inside any active window.
+
+    Args:
+        windows: Parsed (start, end) windows; empty means no restriction
+        now: Time to test (defaults to current local time)
+
+    Returns:
+        True if inside any window or no windows are configured
+    """
+    if not windows:
+        return True
+
+    if now is None:
+        now = datetime.now().time()
+
+    for start, end in windows:
+        if start <= end:
+            # Normal window within a single day
+            if start <= now <= end:
+                return True
+        else:
+            # Window crosses midnight (e.g. 23:00-06:00)
+            if now >= start or now <= end:
+                return True
+
+    return False

--- a/src/daemon/service.py
+++ b/src/daemon/service.py
@@ -8,6 +8,7 @@ from typing import Callable, Awaitable, Optional
 from pathlib import Path
 
 from src.daemon.health import HealthMonitor
+from src.daemon.schedule import parse_active_hours, is_within_active_hours
 from src.notifications.manager import NotificationManager
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,8 @@ class DaemonService:
         check_interval: int,
         health_file: Path,
         check_timeout: Optional[int] = None,
-        notification_manager: Optional[NotificationManager] = None
+        notification_manager: Optional[NotificationManager] = None,
+        active_hours: str = ""
     ):
         """
         Initialize daemon service.
@@ -56,11 +58,15 @@ class DaemonService:
             health_file: Path to health status file
             check_timeout: Optional timeout for check execution (None = no timeout)
             notification_manager: Optional notification manager for sending alerts
+            active_hours: Optional schedule windows ("02:00-08:00,22:00-23:59");
+                checks outside these windows are skipped. Empty = no restriction.
         """
         self.check_function = check_function
         self.check_interval = check_interval
         self.check_timeout = check_timeout
         self.notification_manager = notification_manager
+        self.active_hours = active_hours
+        self.active_windows = parse_active_hours(active_hours) if active_hours else []
         self.shutdown_event = asyncio.Event()
         self.health = HealthMonitor(health_file)
         self.log = logging.getLogger("daemon")
@@ -133,7 +139,20 @@ class DaemonService:
 
         Wraps check_function with error handling and health updates.
         Errors are logged but don't crash the daemon.
+
+        When active hours are configured, checks outside the windows are
+        skipped (the daemon stays alive and healthy). Downloads already in
+        flight when a window closes are never interrupted - the schedule
+        only gates the start of a check.
         """
+        # Schedule gate (issue #36)
+        if self.active_windows and not is_within_active_hours(self.active_windows):
+            self.log.info(
+                f"Outside active hours ({self.active_hours}), skipping check"
+            )
+            self.health.update_status("healthy")
+            return
+
         self.iteration += 1
         self.log.info(f"Starting periodic check (iteration {self.iteration})")
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.organization import build_destination_path, is_duplicate, resolve_confl
 from src.sources.base import BaseSource
 from src.state import CursorStore, DownloadHistory, PendingDownloads
 from src.client import create_client, download_media_with_retry
+from src.client.ratelimit import RateLimiter, parse_rate
 from src.notifications import NotificationManager, DiscordNotifier, GenericWebhook
 
 
@@ -91,6 +92,7 @@ async def download_batch(
     source: BaseSource,
     source_config: SourceConfig,
     history: "DownloadHistory | None" = None,
+    limiter: "RateLimiter | None" = None,
 ) -> tuple[int, set[int]]:
     """Download a batch of messages concurrently with semaphore limit.
 
@@ -106,6 +108,7 @@ async def download_batch(
         source: Source object for this batch
         source_config: Source configuration for folder naming
         history: Optional download history for persistent deduplication
+        limiter: Optional shared RateLimiter capping aggregate download speed
 
     Returns:
         Tuple of (download_count, failed_message_ids).
@@ -181,6 +184,7 @@ async def download_batch(
                 config,
                 log,
                 expected_size=media_size,
+                limiter=limiter,
             )
 
             if success:
@@ -252,7 +256,7 @@ async def startup_validation(cfg, log, client):
     return sources_with_filters
 
 
-async def run_check(cfg, log, state_store, client, sources_with_filters, history=None, pending=None):
+async def run_check(cfg, log, state_store, client, sources_with_filters, history=None, pending=None, limiter=None):
     """
     Single check iteration - process all configured sources.
 
@@ -267,6 +271,7 @@ async def run_check(cfg, log, state_store, client, sources_with_filters, history
         sources_with_filters: Pre-parsed list of (source, filter_config) tuples
         history: Optional DownloadHistory for persistent deduplication
         pending: Optional PendingDownloads queue for resumable downloads
+        limiter: Optional shared RateLimiter capping aggregate download speed
     """
     # Create global concurrency control
     semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
@@ -360,6 +365,7 @@ async def run_check(cfg, log, state_store, client, sources_with_filters, history
             downloaded, failed_ids = await download_batch(
                 candidates, semaphore, client, Path(cfg.download_dir),
                 state_store, cursor_key, cfg, log, source, source_config, history,
+                limiter,
             )
 
             # Remove from pending: orphaned + processed (everything except failures)
@@ -421,6 +427,12 @@ async def main():
         log.warning("Note: Test servers require test phone numbers (99966XXXXXX)")
         log.warning("=" * 60)
 
+    # Optional bandwidth cap shared by all downloads (issue #36)
+    limiter = None
+    if cfg.max_download_speed:
+        limiter = RateLimiter(parse_rate(cfg.max_download_speed))
+        log.info(f"Download speed capped at {cfg.max_download_speed}/s")
+
     # Create Pyrogram client
     client = create_client(cfg)
 
@@ -472,20 +484,21 @@ async def main():
                 # Do NOT re-parse sources in run_check - reuse startup_validation result
                 async def check_wrapper():
                     """Wrapper for run_check that captures sources_with_filters."""
-                    await run_check(cfg, log, state_store, client, sources_with_filters, history, pending)
+                    await run_check(cfg, log, state_store, client, sources_with_filters, history, pending, limiter)
 
                 service = DaemonService(
                     check_function=check_wrapper,
                     check_interval=cfg.daemon.check_interval,
                     health_file=Path(cfg.daemon.health_file),
-                    notification_manager=notification_manager
+                    notification_manager=notification_manager,
+                    active_hours=cfg.schedule_active_hours
                 )
 
                 # Run daemon
                 await service.run()
             else:
                 log.info("Running in single-shot mode")
-                await run_check(cfg, log, state_store, client, sources_with_filters, history, pending)
+                await run_check(cfg, log, state_store, client, sources_with_filters, history, pending, limiter)
     finally:
         # Cleanup
         if history:

--- a/tests/unit/client/test_ratelimit.py
+++ b/tests/unit/client/test_ratelimit.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for bandwidth rate limiting (issue #36).
+
+Covers rate string parsing and token-bucket throttling behavior.
+"""
+import time
+
+import pytest
+
+from src.client.ratelimit import RateLimiter, parse_rate
+
+
+class TestParseRate:
+    """Tests for rate string parsing."""
+
+    def test_megabytes(self):
+        assert parse_rate("5MB") == 5 * 1024 ** 2
+
+    def test_kilobytes(self):
+        assert parse_rate("500KB") == 500 * 1024
+
+    def test_fractional(self):
+        assert parse_rate("1.5MB") == int(1.5 * 1024 ** 2)
+
+    def test_per_second_suffix(self):
+        assert parse_rate("5MB/s") == 5 * 1024 ** 2
+
+    def test_lowercase(self):
+        assert parse_rate("5mb") == 5 * 1024 ** 2
+
+    def test_bare_number_is_bytes(self):
+        assert parse_rate("1024") == 1024
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid download speed"):
+            parse_rate("fast")
+
+    def test_unknown_unit_raises(self):
+        with pytest.raises(ValueError, match="Unknown speed unit"):
+            parse_rate("5XB")
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            parse_rate("0MB")
+
+
+class TestRateLimiter:
+    """Tests for token-bucket throttling."""
+
+    async def test_burst_within_allowance_does_not_sleep(self):
+        limiter = RateLimiter(rate=1024 ** 2)  # 1 MB/s
+        start = time.monotonic()
+        await limiter.throttle(1024)  # 1 KB, well within the 1s burst
+        assert time.monotonic() - start < 0.1
+
+    async def test_over_allowance_sleeps(self):
+        limiter = RateLimiter(rate=10_000)  # 10 KB/s
+        # First call drains the 1s burst; second forces a deficit sleep
+        await limiter.throttle(10_000)
+        start = time.monotonic()
+        await limiter.throttle(5_000)  # 0.5s worth of deficit
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.4
+
+    async def test_zero_bytes_is_noop(self):
+        limiter = RateLimiter(rate=1)
+        start = time.monotonic()
+        await limiter.throttle(0)
+        assert time.monotonic() - start < 0.1

--- a/tests/unit/daemon/test_schedule.py
+++ b/tests/unit/daemon/test_schedule.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for download scheduling (issue #36).
+
+Covers window parsing (single, multiple, cross-midnight) and the
+active-hours check, plus the daemon gate.
+"""
+from datetime import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.daemon.schedule import parse_active_hours, is_within_active_hours
+from src.daemon.service import DaemonService
+
+
+class TestParseActiveHours:
+    """Tests for active-hours spec parsing."""
+
+    def test_single_window(self):
+        assert parse_active_hours("02:00-08:00") == [(time(2, 0), time(8, 0))]
+
+    def test_multiple_windows(self):
+        assert parse_active_hours("02:00-08:00,22:00-23:59") == [
+            (time(2, 0), time(8, 0)),
+            (time(22, 0), time(23, 59)),
+        ]
+
+    def test_cross_midnight_window(self):
+        assert parse_active_hours("23:00-06:00") == [(time(23, 0), time(6, 0))]
+
+    def test_whitespace_tolerated(self):
+        assert parse_active_hours(" 02:00-08:00 , 22:00-23:59 ") == [
+            (time(2, 0), time(8, 0)),
+            (time(22, 0), time(23, 59)),
+        ]
+
+    def test_empty_spec_means_no_windows(self):
+        assert parse_active_hours("") == []
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid active hours"):
+            parse_active_hours("2am-8am")
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="Invalid active hours"):
+            parse_active_hours("25:00-08:00")
+
+
+class TestIsWithinActiveHours:
+    """Tests for the active-hours check."""
+
+    def test_no_windows_always_active(self):
+        assert is_within_active_hours([], time(12, 0)) is True
+
+    def test_inside_normal_window(self):
+        windows = parse_active_hours("02:00-08:00")
+        assert is_within_active_hours(windows, time(5, 0)) is True
+
+    def test_outside_normal_window(self):
+        windows = parse_active_hours("02:00-08:00")
+        assert is_within_active_hours(windows, time(12, 0)) is False
+
+    def test_window_boundaries_inclusive(self):
+        windows = parse_active_hours("02:00-08:00")
+        assert is_within_active_hours(windows, time(2, 0)) is True
+        assert is_within_active_hours(windows, time(8, 0)) is True
+
+    def test_cross_midnight_late_evening(self):
+        windows = parse_active_hours("23:00-06:00")
+        assert is_within_active_hours(windows, time(23, 30)) is True
+
+    def test_cross_midnight_early_morning(self):
+        windows = parse_active_hours("23:00-06:00")
+        assert is_within_active_hours(windows, time(3, 0)) is True
+
+    def test_cross_midnight_daytime_inactive(self):
+        windows = parse_active_hours("23:00-06:00")
+        assert is_within_active_hours(windows, time(12, 0)) is False
+
+    def test_multiple_windows_any_match(self):
+        windows = parse_active_hours("02:00-08:00,22:00-23:59")
+        assert is_within_active_hours(windows, time(22, 30)) is True
+        assert is_within_active_hours(windows, time(15, 0)) is False
+
+
+class TestDaemonScheduleGate:
+    """The daemon skips checks outside active hours."""
+
+    async def test_check_skipped_outside_window(self, tmp_path, monkeypatch):
+        check = AsyncMock()
+        service = DaemonService(
+            check_function=check,
+            check_interval=300,
+            health_file=tmp_path / "health.txt",
+            active_hours="02:00-03:00",
+        )
+        # Force "now" outside the window
+        monkeypatch.setattr(
+            "src.daemon.service.is_within_active_hours", lambda windows: False
+        )
+
+        await service.run_check()
+
+        check.assert_not_awaited()
+        assert service.iteration == 0
+
+    async def test_check_runs_inside_window(self, tmp_path, monkeypatch):
+        check = AsyncMock()
+        service = DaemonService(
+            check_function=check,
+            check_interval=300,
+            health_file=tmp_path / "health.txt",
+            active_hours="02:00-03:00",
+        )
+        monkeypatch.setattr(
+            "src.daemon.service.is_within_active_hours", lambda windows: True
+        )
+
+        await service.run_check()
+
+        check.assert_awaited_once()
+        assert service.iteration == 1
+
+    async def test_no_schedule_always_runs(self, tmp_path):
+        check = AsyncMock()
+        service = DaemonService(
+            check_function=check,
+            check_interval=300,
+            health_file=tmp_path / "health.txt",
+        )
+
+        await service.run_check()
+
+        check.assert_awaited_once()


### PR DESCRIPTION
Fixes #36

- New `TDL_SCHEDULE_ACTIVE_HOURS` setting gates daemon checks to configured time windows (24h local time via TZ); supports multiple comma-separated windows and windows that cross midnight (`23:00-06:00`)
- Outside active hours the daemon logs the skip, keeps updating the health file, and never interrupts a download already in flight - the schedule only gates the start of a check
- New `TDL_MAX_DOWNLOAD_SPEED` setting (e.g. `5MB`) caps aggregate download speed via a shared async token-bucket limiter fed by pyrogram's progress callbacks, so throttling never blocks the event loop
- Both settings validate at startup (clear config errors on bad formats) and default to unrestricted
- Unit tests cover window parsing, cross-midnight logic, the daemon gate, rate parsing and throttle timing; README documents both settings